### PR TITLE
TDetector.findAlignmentInRegion was returning a dangling pointer

### DIFF
--- a/Lib/Classes/2D Barcodes/Detector/AlignmentPattern.pas
+++ b/Lib/Classes/2D Barcodes/Detector/AlignmentPattern.pas
@@ -27,6 +27,7 @@ type
   private
     estimatedModuleSize: Single;
   public
+    constructor Clone(const src:TAlignmentPattern); reintroduce;
     constructor Create(posX: Single; posY: Single; estimatedModuleSize: Single);
     function aboutEquals(moduleSize: Single; i: Single; j: Single): boolean;
     function combineEstimate(i: Single; j: Single; newModuleSize: Single)
@@ -60,6 +61,12 @@ begin
   end;
 
   Result := false;
+end;
+
+constructor TAlignmentPattern.Clone(const src: TAlignmentPattern);
+begin
+  inherited Clone(src);
+  self.estimatedModuleSize  := src.estimatedModuleSize;
 end;
 
 function TAlignmentPattern.combineEstimate(i: Single; j: Single;

--- a/Lib/Classes/2D Barcodes/Detector/Detector.pas
+++ b/Lib/Classes/2D Barcodes/Detector/Detector.pas
@@ -244,6 +244,8 @@ var
   allowance, alignmentAreaRightX, alignmentAreaLeftX, alignmentAreaTopY,
     alignmentAreaBottomY: Integer;
   alignmentFinder: TAlignmentPatternFinder;
+
+  candidateResult:TAlignmentPattern;
 begin
 
   allowance := Floor(allowanceFactor * overallEstModuleSize);
@@ -267,8 +269,14 @@ begin
     (alignmentAreaBottomY - alignmentAreaTopY), overallEstModuleSize,
     self.ResultPointCallback);
 
-  Result := alignmentFinder.find;
-  FreeAndNil(alignmentFinder);
+  candidateResult := alignmentFinder.find;
+
+  if candidateResult = nil then
+     result := nil
+  else
+     result := TAlignmentPattern.Clone(candidateResult);
+
+  FreeAndNil(alignmentFinder);  // note: this, under Win32 will destroy the object returned by alignmentFinder.find: this is why I am returning a clone of it
 
 end;
 

--- a/Lib/Classes/Common/ResultPoint.pas
+++ b/Lib/Classes/Common/ResultPoint.pas
@@ -34,6 +34,7 @@ type
       : single; static;
 
   public
+    constructor Clone(const src:TResultPoint);
     constructor Create(pX, pY: single);
     destructor Destroy(); override;
     function Equals(other: TObject): Boolean; override;
@@ -60,6 +61,16 @@ type
 implementation
 
 { TResultPoint }
+
+constructor TResultPoint.Clone(const src: TResultPoint);
+begin
+   inherited Create;
+   self.Fx := src.Fx;
+   self.Fy := src.Fy;
+   self.bytesX := src.bytesX;
+   self.bytesY := src.bytesY;
+   self.FToString := src.FToString;
+end;
 
 constructor TResultPoint.Create(pX, pY: single);
 

--- a/Lib/Classes/ScanManager.pas
+++ b/Lib/Classes/ScanManager.pas
@@ -89,6 +89,9 @@ var
   HybridBinarizer: THybridBinarizer;
   BinaryBitmap: TBinaryBitmap;
 begin
+  RGBLuminanceSource := nil;
+  HybridBinarizer := nil;
+  BinaryBitmap := nil;
   try
     RGBLuminanceSource := TRGBLuminanceSource.RGBLuminanceSource(pBitmapForScan,
       pBitmapForScan.Width, pBitmapForScan.Height);
@@ -99,21 +102,9 @@ begin
 
     Result := FMultiFormatReader.Decode(BinaryBitmap, true);
   finally
-
-    if (BinaryBitmap <> nil) then
-    begin
-      BinaryBitmap.Free;
-    end;
-
-    if (HybridBinarizer <> nil) then
-    begin
-      HybridBinarizer.Free;
-    end;
-
-    if (RGBLuminanceSource <> nil) then
-    begin
-      RGBLuminanceSource.Free;
-    end;
+    BinaryBitmap.Free;
+    HybridBinarizer.Free;
+    RGBLuminanceSource.Free;
   end;
 end;
 


### PR DESCRIPTION
This was the original code:

  Result := alignmentFinder.find;
  FreeAndNil(alignmentFinder);
end;
AlignmentFinder is returining a pointer to an item contained in member TList. The FreeAndNil was destroiyng the whole aligmnentFinder, including the tlist and the contained objects... So result was pointing to a deallocated block of memory, that led to access violations when the calling program tried to free the same block a second time.

 This happens when you compile for the "old-gen" compilers (win32, win64,OsX) that do not have any automatic reference counting of object instances