### PR TITLE
Fixed all memory leaks under old-gen compilers (Win32/Win64)

### DIFF
--- a/Lib/Classes/1D Barcodes/Code128Reader.pas
+++ b/Lib/Classes/1D Barcodes/Code128Reader.pas
@@ -136,7 +136,8 @@ class function TCode128Reader.FindStartPattern(row: TBitArray): TArray<Integer>;
 var
   i, bestMatch, startCode, bestVariance, width, rowOffset, patternStart,
     patternLength, variance, counterPosition: Integer;
-  counters, CopyCounters: TArray<Integer>;
+  counters:TArray<Integer>;
+  // CopyCounters:TArray<Integer>; // never used
   isWhite: Boolean;
 
 begin
@@ -264,10 +265,10 @@ var
   aResult: String;
   counter, resultLength, i: Integer;
   left, right: Single;
-  resultPointCallback: TResultPointCallback;
-  ReadResult: TReadResult;
-  resultPoints: TArray<TResultPoint>;
-  resultPointLeft, resultPointRight: TResultPoint;
+//   resultPointCallback: TResultPointCallback; never used
+//  ReadResult: TReadResult; never used
+  resultPoints: TArray<IResultPoint>;
+  resultPointLeft, resultPointRight: IResultPoint;
 
 begin
   convertFNC1 := (hints <> nil) and
@@ -684,8 +685,8 @@ begin
       rawBytes[i] := rawCodes[i]
     end;
 
-    resultPointLeft := TResultPoint.Create(left, rowNumber);
-    resultPointRight := TResultPoint.Create(right, rowNumber);
+    resultPointLeft := TResultPointHelpers.CreateResultPoint(left, rowNumber);
+    resultPointRight := TResultPointHelpers.CreateResultPoint(right, rowNumber);
     resultPoints := [resultPointLeft, resultPointRight];
 
   finally

--- a/Lib/Classes/1D Barcodes/Code93Reader.pas
+++ b/Lib/Classes/1D Barcodes/Code93Reader.pas
@@ -260,8 +260,8 @@ var
   resultString: String;
   Left, Right: Single;
   // resultPointCallback: TResultPointCallback;
-  resultPoints: TArray<TResultPoint>;
-  resultPointLeft, resultPointRight: TResultPoint;
+  resultPoints: TArray<IResultPoint>;
+  resultPointLeft, resultPointRight: IResultPoint;
 
 begin
   for index := 0 to length(counters) - 1 do
@@ -347,8 +347,8 @@ begin
   Left := (start[1] + start[0]) div 2;
   Right := (lastStart + lastPatternSize) div 2;
 
-  resultPointLeft := TResultPoint.Create(Left, rowNumber);
-  resultPointRight := TResultPoint.Create(Right, rowNumber);
+  resultPointLeft := TResultPointHelpers.CreateResultPoint(Left, rowNumber);
+  resultPointRight := TResultPointHelpers.CreateResultPoint(Right, rowNumber);
   resultPoints := [resultPointLeft, resultPointRight];
 
   Result := TReadResult.Create(resultString, nil, resultPoints,

--- a/Lib/Classes/1D Barcodes/ITFReader.pas
+++ b/Lib/Classes/1D Barcodes/ITFReader.pas
@@ -102,8 +102,8 @@ var
   len: Integer;
   lengthOK: boolean;
   SBResult: TStringBuilder;
-  resultPoints: TArray<TResultPoint>;
-  resultPointLeft, resultPointRight: TResultPoint;
+  resultPoints: TArray<IResultPoint>;
+  resultPointLeft, resultPointRight: IResultPoint;
 
 begin
   startRange := decodeStart(row);
@@ -174,8 +174,8 @@ begin
 
   end;
 
-  resultPointLeft := TResultPoint.Create(startRange[1], rowNumber);
-  resultPointRight := TResultPoint.Create(endRange[0], rowNumber);
+  resultPointLeft := TResultPointHelpers.CreateResultPoint(startRange[1], rowNumber);
+  resultPointRight := TResultPointHelpers.CreateResultPoint(endRange[0], rowNumber);
   resultPoints := [resultPointLeft, resultPointRight];
 
   Result := TReadResult.Create(stringResult, nil, resultPoints,
@@ -341,7 +341,7 @@ var
   counterPosition: Integer;
   patternStart: Integer;
   x: Integer;
-  l: Integer;
+//   l: Integer; never used
 begin
   patternLength := Length(pattern);
   counters := TArray<Integer>.Create();

--- a/Lib/Classes/1D Barcodes/OneDReader.pas
+++ b/Lib/Classes/1D Barcodes/OneDReader.pas
@@ -174,7 +174,7 @@ var
   rotatedImage: TBinaryBitmap;
   metadata: TDictionary<TResultMetadataType, TObject>;
   orientation, height, i, l: Integer;
-  points: TArray<TResultPoint>;
+  points: TArray<IResultPoint>;
 
 begin
   Result := DoDecode(image, hints);
@@ -220,7 +220,7 @@ begin
       l := Length(points) - 1;
       for i := 0 to l do
       begin
-        points[i] := TResultPoint.Create(height - points[i].Y - 1, points[i].X);
+        points[i] := TResultPointHelpers.CreateResultPoint(height - points[i].Y - 1, points[i].X);
       end;
     end;
 
@@ -238,7 +238,7 @@ var
   tryHarder, isAbove: Boolean;
   newHints: TDictionary<TDecodeHintType, TObject>;
   ReadResult: TReadResult;
-  points: TArray<TResultPoint>;
+  points: TArray<IResultPoint>;
   Key: TDecodeHintType;
 
 begin
@@ -344,10 +344,8 @@ begin
           points := ReadResult.ResultPoints;
           if (points <> nil) then
           begin
-            points[0] := TResultPoint.Create(width - points[0].X - 1,
-              points[0].Y);
-            points[1] := TResultPoint.Create(width - points[1].X - 1,
-              points[1].Y);
+            points[0] := TResultPointHelpers.CreateResultPoint(width - points[0].X - 1,points[0].Y);
+            points[1] := TResultPointHelpers.CreateResultPoint(width - points[1].X - 1,points[1].Y);
           end;
 
         end;

--- a/Lib/Classes/2D Barcodes/Decoder/QRCodeDecoderMetadata.pas
+++ b/Lib/Classes/2D Barcodes/Decoder/QRCodeDecoderMetadata.pas
@@ -31,7 +31,7 @@ type
   public
     property IsMirrored: boolean read get_IsMirrored;
     constructor Create(mirrored: boolean);
-    procedure applyMirroredCorrection(points: TArray<TResultPoint>);
+    procedure applyMirroredCorrection(points: TArray<IResultPoint>);
   end;
 
 implementation
@@ -47,9 +47,9 @@ begin
 end;
 
 procedure TQRCodeDecoderMetaData.applyMirroredCorrection
-  (points: TArray<TResultPoint>);
+  (points: TArray<IResultPoint>);
 var
-  bottomLeft: TResultPoint;
+  bottomLeft: IResultPoint;
 begin
   if ((FMirrored and (points <> nil)) and (Length(points) >= 3)) then
   begin

--- a/Lib/Classes/2D Barcodes/Decoder/Version.pas
+++ b/Lib/Classes/2D Barcodes/Decoder/Version.pas
@@ -42,7 +42,7 @@ type
     public
       ecCodewordsPerBlock: Integer;
       constructor Create(ecCodewordsPerBlock: Integer; ecBlocks: TArray<TECB>);
-      destructor destroy();override;
+      destructor Destroy();override;
       function getECBlocks: TArray<TECB>;
       { property ecCodewordsPerBlock: Integer read get_ECCodewordsPerBlock;
         property NumBlocks: Integer read get_NumBlocks;

--- a/Lib/Classes/2D Barcodes/Detector/AlignmentPattern.pas
+++ b/Lib/Classes/2D Barcodes/Detector/AlignmentPattern.pas
@@ -23,61 +23,26 @@ uses Resultpoint;
 
 type
 
-  TAlignmentPattern = class sealed(TResultpoint)
-  private
-    estimatedModuleSize: Single;
-  public
-    constructor Clone(const src:TAlignmentPattern); reintroduce;
-    constructor Create(posX: Single; posY: Single; estimatedModuleSize: Single);
-    function aboutEquals(moduleSize: Single; i: Single; j: Single): boolean;
-    function combineEstimate(i: Single; j: Single; newModuleSize: Single)
-      : TAlignmentPattern;
+  IAlignmentPattern = interface(IResultPoint)
+    ['{B75C2D62-002F-4DAD-AE99-2E5FB8CFAB52}']
+     function aboutEquals(const moduleSize,i,j: Single): boolean;
+     function combineEstimate(const i,j,newModuleSize: Single):IAlignmentPattern;
   end;
+
+
+
+  TAlignmentPatternHelpers = class
+     class function CreateAlignmentPattern(const posX,posY,estimatedModuleSize: Single):IAlignmentPattern;
+  end;
+
 
 implementation
+uses AlignmentPatternImpl;
 
-constructor TAlignmentPattern.Create(posX: Single; posY: Single;
-  estimatedModuleSize: Single);
+class function TAlignmentPatternHelpers.CreateAlignmentPattern(const posX,posY,estimatedModuleSize: Single):IAlignmentPattern;
 begin
-  inherited Create(posX, posY);
-  self.estimatedModuleSize := estimatedModuleSize;
+  result := AlignmentPatternImpl.NewAlignmentPattern(posx,posy,estimatedModuleSize)
 end;
 
-function TAlignmentPattern.aboutEquals(moduleSize: Single; i: Single;
-  j: Single): boolean;
-
-var
-  moduleSizeDiff: Single;
-
-begin
-  if ((Abs(i - self.y) <= moduleSize) and (Abs(j - self.x) <= moduleSize)) then
-  begin
-    moduleSizeDiff := Abs(moduleSize - self.estimatedModuleSize);
-    begin
-      Result := ((moduleSizeDiff <= 1) or
-        (moduleSizeDiff <= self.estimatedModuleSize));
-      exit
-    end
-  end;
-
-  Result := false;
-end;
-
-constructor TAlignmentPattern.Clone(const src: TAlignmentPattern);
-begin
-  inherited Clone(src);
-  self.estimatedModuleSize  := src.estimatedModuleSize;
-end;
-
-function TAlignmentPattern.combineEstimate(i: Single; j: Single;
-  newModuleSize: Single): TAlignmentPattern;
-var
-  combinedX, combinedY: Single;
-begin
-  combinedX := ((self.x + j) / 2);
-  combinedY := ((self.y + i) / 2);
-  Result := TAlignmentPattern.Create(combinedX, combinedY,
-    ((self.estimatedModuleSize + newModuleSize) / 2))
-end;
 
 end.

--- a/Lib/Classes/2D Barcodes/Detector/AlignmentPatternFinder.pas
+++ b/Lib/Classes/2D Barcodes/Detector/AlignmentPatternFinder.pas
@@ -32,7 +32,7 @@ type
     moduleSize: Single;
     width: Integer;
     startX, startY: Integer;
-    possibleCenters: TList<TAlignmentPattern>;
+    possibleCenters: TList<IAlignmentPattern>;
     resultPointCallback: TResultPointCallback;
 
     class function centerFromEnd(stateCount: TArray<Integer>; pEnd: Integer)
@@ -41,14 +41,14 @@ type
       maxCount: Integer; originalStateCountTotal: Integer): Single;
     function foundPatternCross(stateCount: TArray<Integer>): boolean;
     function handlePossibleCenter(stateCount: TArray<Integer>; i: Integer;
-      j: Integer): TAlignmentPattern;
+      j: Integer): IAlignmentPattern;
 
   public
     constructor Create(image: TBitMatrix; startX: Integer; startY: Integer;
       width: Integer; height: Integer; moduleSize: Single;
       resultPointCallback: TResultPointCallback);
     destructor Destroy();override;
-    function find: TAlignmentPattern;
+    function find: IAlignmentPattern;
 
   end;
 
@@ -67,7 +67,7 @@ constructor TAlignmentPatternFinder.Create(image: TBitMatrix;
   resultPointCallback: TResultPointCallback);
 begin
   self.image := image;
-  self.possibleCenters := TList<TAlignmentPattern>.Create();
+  self.possibleCenters := TList<IAlignmentPattern>.Create();
   self.possibleCenters.Capacity := 5;
   self.startX := startX;
   self.startY := startY;
@@ -80,15 +80,10 @@ begin
 end;
 
 destructor TAlignmentPatternFinder.Destroy;
-var alignmentPattern : TAlignmentPattern;
+var alignmentPattern : IAlignmentPattern;
 begin
-
-  for alignmentPattern in possibleCenters do
-  begin
-    alignmentPattern.Free;
-  end;
-
-  self.possibleCenters.Clear;
+  if possibleCenters<> nil then
+     possibleCenters.Clear;
   FreeAndNil(self.possibleCenters);
   self.crossCheckStateCount := nil;
   self.resultPointCallback :=nil;
@@ -180,9 +175,9 @@ begin
   result := -1;
 end;
 
-function TAlignmentPatternFinder.find: TAlignmentPattern;
+function TAlignmentPatternFinder.find: IAlignmentPattern;
 var
-  confirmed: TAlignmentPattern;
+  confirmed: IAlignmentPattern;
   maxJ, middleI, iGen, i, j, currentState: Integer;
   stateCount: TArray<Integer>;
 begin
@@ -306,9 +301,9 @@ begin
 end;
 
 function TAlignmentPatternFinder.handlePossibleCenter
-  (stateCount: TArray<Integer>; i, j: Integer): TAlignmentPattern;
+  (stateCount: TArray<Integer>; i, j: Integer): IAlignmentPattern;
 var
-  center, point: TAlignmentPattern;
+  center, point: IAlignmentPattern;
   stateCountTotal: Integer;
   estimatedModuleSize: Single;
   centerJ, centerI: Single;
@@ -340,7 +335,7 @@ begin
 
       end;
 
-      point := TAlignmentPattern.Create(centerJ, centerI, estimatedModuleSize);
+      point := TAlignmentPatternHelpers.CreateAlignmentPattern(centerJ, centerI, estimatedModuleSize);
 
 
 

--- a/Lib/Classes/2D Barcodes/Detector/AlignmentPatternImpl.pas
+++ b/Lib/Classes/2D Barcodes/Detector/AlignmentPatternImpl.pas
@@ -1,0 +1,64 @@
+unit AlignmentPatternImpl;
+
+interface
+uses AlignmentPattern;
+
+   function NewAlignmentPattern(const posX: Single; posY: Single; const estimatedModuleSize: Single):IAlignmentPattern;
+
+implementation
+uses ResultPoint,ResultPointImpl;
+
+type
+  TAlignmentPatternImpl = class (TResultPointImpl, IResultpoint, IAlignmentPattern)
+  protected
+     constructor Create(posX: Single; posY: Single; estimatedModuleSize: Single);
+  strict private
+     estimatedModuleSize: Single;
+     function aboutEquals(const moduleSize,i,j: Single): boolean;
+     function combineEstimate(const i, j, newModuleSize: Single):IAlignmentPattern;
+  end;
+
+
+function NewAlignmentPattern(const posX: Single; posY: Single; const estimatedModuleSize: Single):IAlignmentPattern;
+begin
+   result :=  TAlignmentPatternImpl.Create(posx,posy,estimatedModuleSize);
+end;
+
+
+
+
+constructor TAlignmentPatternImpl.Create(posX: Single; posY: Single;
+  estimatedModuleSize: Single);
+begin
+  inherited Create(posX, posY);
+  self.estimatedModuleSize := estimatedModuleSize;
+end;
+
+function TAlignmentPatternImpl.aboutEquals(const moduleSize,i,j: Single): boolean;
+var
+  moduleSizeDiff: Single;
+begin
+  if ((Abs(i - self.y) <= moduleSize) and (Abs(j - self.x) <= moduleSize)) then
+  begin
+    moduleSizeDiff := Abs(moduleSize - self.estimatedModuleSize);
+    begin
+      Result := ((moduleSizeDiff <= 1) or
+        (moduleSizeDiff <= self.estimatedModuleSize));
+      exit
+    end
+  end;
+
+  Result := false;
+end;
+
+function TAlignmentPatternImpl.combineEstimate(const i,j,newModuleSize: Single): IAlignmentPattern;
+var
+  combinedX, combinedY: Single;
+begin
+  combinedX := ((self.x + j) / 2);
+  combinedY := ((self.y + i) / 2);
+  Result := TAlignmentPatternImpl.Create(combinedX, combinedY,
+    ((self.estimatedModuleSize + newModuleSize) / 2))
+end;
+
+end.

--- a/Lib/Classes/2D Barcodes/Detector/FinderPattern.pas
+++ b/Lib/Classes/2D Barcodes/Detector/FinderPattern.pas
@@ -22,74 +22,31 @@ interface
 uses Resultpoint;
 
 type
-  TFinderPattern = class(TResultpoint)
-  public
-    constructor Create(posX: Single; posY: Single;
-      estimatedModuleSize: Single); overload;
-    constructor Create(posX: Single; posY: Single; estimatedModuleSize: Single;
-      count: Integer); overload;
-    function aboutEquals(moduleSize: Single; i: Single; j: Single): boolean;
-    function combineEstimate(i: Single; j: Single; newModuleSize: Single)
-      : TFinderPattern;
-
-  var
-    count: Integer;
-    estimatedModuleSize: Single;
+  IFinderPattern = interface(IResultPoint)
+    ['{8F123EA3-5A12-4C25-BFD1-49C6DB24D9C1}']
+    function aboutEquals(const moduleSize,i,j: Single): boolean;
+    function combineEstimate(const i,j,newModuleSize: Single): IFinderPattern;
+    function Count:integer;
+    function EstimatedModuleSize: Single;
   end;
+
+  TFinderPatternHelpers = class
+    class function CreateFinderPattern(const posX,posY,estimatedModuleSize: Single):IFinderPattern; overload;
+    class function CreateFinderPattern(const posX,posY,estimatedModuleSize: Single; const count :integer):IFinderPattern; overload;
+  end;
+
 
 implementation
+uses FinderPatternImpl;
 
-constructor TFinderPattern.Create(posX: Single; posY: Single;
-  estimatedModuleSize: Single);
+class function TFinderPatternHelpers.CreateFinderPattern(const posX,posY,estimatedModuleSize: Single):IFinderPattern;
 begin
-  inherited Create(posX, posY);
-  self.estimatedModuleSize := estimatedModuleSize;
-  self.count := 1
+   result := FinderPatternImpl.NewFinderPattern(posX,posY,estimatedModuleSize);
 end;
 
-constructor TFinderPattern.Create(posX: Single; posY: Single;
-  estimatedModuleSize: Single; count: Integer);
+class function TFinderPatternHelpers.CreateFinderPattern(const posX,posY,estimatedModuleSize: Single; const count :integer):IFinderPattern;
 begin
-  inherited Create(posX, posY);
-  self.estimatedModuleSize := estimatedModuleSize;
-  self.count := count
-end;
-
-function TFinderPattern.aboutEquals(moduleSize: Single; i: Single;
-  j: Single): boolean;
-var
-  moduleSizeDiff, x, y: Single;
-
-begin
-  x := self.x;
-  y := self.y;
-  if ((Abs(i - self.y) <= moduleSize) and (Abs(j - self.x) <= moduleSize)) then
-  begin
-
-    moduleSizeDiff := Abs(moduleSize - self.estimatedModuleSize);
-
-    Result := ((moduleSizeDiff <= 1) or
-      (moduleSizeDiff <= self.estimatedModuleSize));
-    exit
-  end;
-
-  Result := false;
-
-end;
-
-function TFinderPattern.combineEstimate(i: Single; j: Single;
-  newModuleSize: Single): TFinderPattern;
-var
-  combinedCount: Integer;
-  combinedX, combinedY: Single;
-
-begin
-  combinedCount := (self.count + 1);
-  combinedX := ((self.count * self.x) + j) / combinedCount;
-  combinedY := ((self.count * self.y) + i) / combinedCount;
-  Result := TFinderPattern.Create(combinedX, combinedY,
-    (((self.count * self.estimatedModuleSize) + newModuleSize) / combinedCount),
-    combinedCount)
+   result := FinderPatternImpl.NewFinderPattern(posX,posY,estimatedModuleSize,count);
 end;
 
 end.

--- a/Lib/Classes/2D Barcodes/Detector/FinderPatternImpl.pas
+++ b/Lib/Classes/2D Barcodes/Detector/FinderPatternImpl.pas
@@ -1,0 +1,104 @@
+unit FinderPatternImpl;
+
+interface
+uses FinderPattern;
+
+
+function NewFinderPattern(const posX,posY,estimatedModuleSize: Single):IFinderPattern; overload;
+function NewFinderPattern(const posX,posY,estimatedModuleSize: Single; const count :integer):IFinderPattern; overload;
+
+
+implementation
+uses ResultPoint,ResultPointImpl;
+
+type
+  TFinderPatternImpl = class(TResultPointImpl,IResultPoint,IFinderPattern)
+  strict private
+    FCount: Integer;
+    FEstimatedModuleSize: Single;
+  public
+    function aboutEquals(const moduleSize,i,j: Single): boolean;
+    function combineEstimate(const i,j,newModuleSize: Single) : IFinderPattern;
+    function Count:integer;
+    function EstimatedModuleSize: Single;
+  protected
+    constructor Create(const posX,posY,estimatedModuleSize: Single); overload;
+    constructor Create(const posX,posY,estimatedModuleSize: Single; const count :integer); overload;
+  end;
+
+
+
+constructor TFinderPatternImpl.Create(const posX,posY,estimatedModuleSize: Single);
+begin
+  inherited Create(posX, posY);
+  self.FEstimatedModuleSize := estimatedModuleSize;
+  self.FCount := 1
+end;
+
+function TFinderPatternImpl.Count: integer;
+begin
+  result := FCount;
+end;
+
+constructor TFinderPatternImpl.Create(const posX,posY,estimatedModuleSize: Single; const count :integer);
+begin
+  inherited Create(posX, posY);
+  self.FEstimatedModuleSize := estimatedModuleSize;
+  self.FCount := count
+end;
+
+function TFinderPatternImpl.EstimatedModuleSize: Single;
+begin
+  result := FEstimatedModuleSize;
+end;
+
+function TFinderPatternImpl.aboutEquals(const moduleSize,i,j: Single): boolean;
+var
+  moduleSizeDiff, x, y: Single;
+
+begin
+  x := self.x;
+  y := self.y;
+  if ((Abs(i - self.y) <= moduleSize) and (Abs(j - self.x) <= moduleSize)) then
+  begin
+
+    moduleSizeDiff := Abs(moduleSize - self.estimatedModuleSize);
+
+    Result := ((moduleSizeDiff <= 1) or
+      (moduleSizeDiff <= self.estimatedModuleSize));
+    exit
+  end;
+
+  Result := false;
+
+end;
+
+function TFinderPatternImpl.combineEstimate(const i,j,newModuleSize: Single): IFinderPattern;
+var
+  combinedCount: Integer;
+  combinedX, combinedY: Single;
+
+begin
+  combinedCount := (self.count + 1);
+  combinedX := ((self.count * self.x) + j) / combinedCount;
+  combinedY := ((self.count * self.y) + i) / combinedCount;
+  Result := TFinderPatternImpl.Create(combinedX, combinedY,
+    (((self.count * self.estimatedModuleSize) + newModuleSize) / combinedCount),
+    combinedCount)
+end;
+
+
+
+
+function NewFinderPattern(const posX,posY,estimatedModuleSize: Single):IFinderPattern; overload;
+begin
+   result := TFinderPatternImpl.Create(posX,posY,estimatedModuleSize);
+end;
+
+function NewFinderPattern(const posX,posY,estimatedModuleSize: Single; const count :integer):IFinderPattern; overload;
+begin
+   result := TFinderPatternImpl.Create(posX,posY,estimatedModuleSize,count);
+end;
+
+
+end.

--- a/Lib/Classes/2D Barcodes/Detector/FinderPatternInfo.pas
+++ b/Lib/Classes/2D Barcodes/Detector/FinderPatternInfo.pas
@@ -26,15 +26,15 @@ type
   TFinderPatternInfo = class sealed
   public
   var
-    bottomLeft: TFinderPattern;
-    topLeft: TFinderPattern;
-    topRight: TFinderPattern;
-    constructor Create(patternCenters: TArray<TFinderPattern>);
+    bottomLeft: IFinderPattern;
+    topLeft: IFinderPattern;
+    topRight: IFinderPattern;
+    constructor Create(patternCenters: TArray<IFinderPattern>);
   end;
 
 implementation
 
-constructor TFinderPatternInfo.Create(patternCenters: TArray<TFinderPattern>);
+constructor TFinderPatternInfo.Create(patternCenters: TArray<IFinderPattern>);
 begin
   self.bottomLeft := patternCenters[0];
   self.topLeft := patternCenters[1];

--- a/Lib/Classes/2D Barcodes/QRCodeReader.pas
+++ b/Lib/Classes/2D Barcodes/QRCodeReader.pas
@@ -32,7 +32,7 @@ type
   private
     // Fields
     Decoder: TQRDecoder;
-    NO_POINTS: TArray<TResultPoint>;
+    NO_POINTS: TArray<IResultPoint>;
 
     class function extractPureBits(image: TBitMatrix): TBitMatrix; static;
     class function moduleSize(leftTopBlack: TArray<Integer>; image: TBitMatrix;
@@ -63,7 +63,7 @@ constructor TQRCodeReader.Create;
 begin
   inherited;
 
-  NO_POINTS := TArray<TResultPoint>.Create();
+  NO_POINTS := TArray<IResultPoint>.Create();
 end;
 
 function TQRCodeReader.decode(image: TBinaryBitmap;
@@ -71,7 +71,7 @@ function TQRCodeReader.decode(image: TBinaryBitmap;
 var
   DecoderResult: TDecoderResult;
   Detector: TDetector;
-  points: TArray<TResultPoint>;
+  points: TArray<IResultPoint>;
   bits: TBitMatrix;
   DetectorResult: TDetectorResult;
   data: TQRCodeDecoderMetaData;

--- a/Lib/Classes/Common/BarcodeFormat.pas
+++ b/Lib/Classes/Common/BarcodeFormat.pas
@@ -85,8 +85,8 @@ type
     /// UPC_A | UPC_E | EAN_13 | EAN_8 | CODABAR | CODE_39 | CODE_93 | CODE_128 | ITF | RSS_14 | RSS_EXPANDED
     /// without MSI (to many false-positives)
     /// </summary>
-    All_1D = UPC_A or UPC_E or EAN_13 or EAN_8 or CODABAR or CODE_39 or
-    CODE_93 or CODE_128 or ITF or RSS_14 or RSS_EXPANDED
+    // note: used "+" instead of "bitwise or" to avoid a compiler warning about signed/unsigned assignment
+    All_1D =  UPC_A + UPC_E + EAN_13 + EAN_8 + CODABAR + CODE_39 + CODE_93 + CODE_128 + ITF + RSS_14 + RSS_EXPANDED
 
     );
 

--- a/Lib/Classes/Common/CharacterSetECI.pas
+++ b/Lib/Classes/Common/CharacterSetECI.pas
@@ -33,18 +33,22 @@ type
   end;
 
   TCharacterSetECI = class sealed(TECI)
-  private
+  strict private
     FEncodingName: string;
     class var NAME_TO_ECI: TDictionary<string, TCharacterSetECI>;
     class var VALUE_TO_ECI: TDictionary<Integer, TCharacterSetECI>;
+    ///<summary>
+    /// this objectlist is just for doing proper deallocation of TCharacterSetECI instances under Win32/Win64,
+    /// without having to mess with TInterfacedObject. Since instances are meant to exist for the whole program life, there's no need of doing
+    /// anything much more complicated than this.
+    /// </summary>
+    class var AllocatedInstances:TObjectList<TCharacterSetECI>;
 
-    constructor Create; overload;
+    class constructor Create;
     constructor Create(value: Integer; encodingName: string); overload;
+    class destructor Destroy;
 
-    class procedure addCharacterSet(value: Integer; encodingName: string);
-      overload; static;
-    class procedure addCharacterSet(value: Integer;
-      encodingNames: TArray<string>); overload; static;
+    class procedure addCharacterSet(value: Integer;  encodingNames: TArray<string>); static;
 
   public
 
@@ -86,91 +90,73 @@ end;
 constructor TCharacterSetECI.Create(value: Integer; encodingName: string);
 begin
   inherited Create(value);
-  FEncodingName := encodingName
+  FEncodingName := encodingName;
+  AllocatedInstances.Add(self); // add the instance to the global list of all created instances
 end;
 
-constructor TCharacterSetECI.Create;
+class destructor TCharacterSetECI.Destroy;
 begin
-  TCharacterSetECI.addCharacterSet(0, 'CP437');
-  TCharacterSetECI.addCharacterSet(1, TArray<string>.Create('ISO-8859-1',
-    'ISO8859_1'));
-  TCharacterSetECI.addCharacterSet(2, 'CP437');
-  TCharacterSetECI.addCharacterSet(3, TArray<string>.Create('ISO-8859-1',
-    'ISO8859_1'));
-  TCharacterSetECI.addCharacterSet(4, TArray<string>.Create('ISO-8859-2',
-    'ISO8859_2'));
-  TCharacterSetECI.addCharacterSet(5, TArray<string>.Create('ISO-8859-3',
-    'ISO8859_3'));
-  TCharacterSetECI.addCharacterSet(6, TArray<string>.Create('ISO-8859-4',
-    'ISO8859_4'));
-  TCharacterSetECI.addCharacterSet(7, TArray<string>.Create('ISO-8859-5',
-    'ISO8859_5'));
-  TCharacterSetECI.addCharacterSet(8, TArray<string>.Create('ISO-8859-6',
-    'ISO8859_6'));
-  TCharacterSetECI.addCharacterSet(9, TArray<string>.Create('ISO-8859-7',
-    'ISO8859_7'));
-  TCharacterSetECI.addCharacterSet(10, TArray<string>.Create('ISO-8859-8',
-    'ISO8859_8'));
-  TCharacterSetECI.addCharacterSet(11, TArray<string>.Create('ISO-8859-9',
-    'ISO8859_9'));
-  TCharacterSetECI.addCharacterSet(12, TArray<string>.Create('ISO-8859-4',
-    'ISO-8859-10', 'ISO8859_10'));
-  TCharacterSetECI.addCharacterSet(13, TArray<string>.Create('ISO-8859-11',
-    'ISO8859_11'));
-  TCharacterSetECI.addCharacterSet(15, TArray<string>.Create('ISO-8859-13',
-    'ISO8859_13'));
-  TCharacterSetECI.addCharacterSet($10, TArray<string>.Create('ISO-8859-1',
-    'ISO-8859-14', 'ISO8859_14'));
-  TCharacterSetECI.addCharacterSet($11, TArray<string>.Create('ISO-8859-15',
-    'ISO8859_15'));
-  TCharacterSetECI.addCharacterSet($12, TArray<string>.Create('ISO-8859-3',
-    'ISO-8859-16', 'ISO8859_16'));
-  TCharacterSetECI.addCharacterSet(20, TArray<string>.Create('SJIS',
-    'Shift_JIS'));
-  TCharacterSetECI.addCharacterSet($15, TArray<string>.Create('WINDOWS-1250',
-    'CP1250'));
-  TCharacterSetECI.addCharacterSet($16, TArray<string>.Create('WINDOWS-1251',
-    'CP1251'));
-  TCharacterSetECI.addCharacterSet($17, TArray<string>.Create('WINDOWS-1252',
-    'CP1252'));
-  TCharacterSetECI.addCharacterSet($18, TArray<string>.Create('WINDOWS-1256',
-    'CP1256'));
-  TCharacterSetECI.addCharacterSet($19, TArray<string>.Create('UTF-16BE',
-    'UNICODEBIG'));
-  TCharacterSetECI.addCharacterSet($1A, TArray<string>.Create('UTF-8', 'UTF8'));
-  TCharacterSetECI.addCharacterSet($1B, 'US-ASCII');
-  TCharacterSetECI.addCharacterSet(170, 'US-ASCII');
-  TCharacterSetECI.addCharacterSet($1C, 'BIG5');
-  TCharacterSetECI.addCharacterSet($1D, TArray<string>.Create('GB18030',
-    'GB2312', 'EUC_CN', 'GBK'));
-  TCharacterSetECI.addCharacterSet(30, TArray<string>.Create('EUC-KR',
-    'EUC_KR'))
+   NAME_TO_ECI.Free;
+   VALUE_TO_ECI.Free;
+
+   if  AllocatedInstances<>nil then begin
+      AllocatedInstances.Clear;
+      AllocatedInstances.Free;
+   end;
 
 end;
 
-class procedure TCharacterSetECI.addCharacterSet(value: Integer;
-  encodingNames: TArray<string>);
+class constructor TCharacterSetECI.Create;
+begin
+  NAME_TO_ECI:=TDictionary<string, TCharacterSetECI>.Create;
+  VALUE_TO_ECI:=TDictionary<Integer, TCharacterSetECI>.Create;
+  // under Win32/64 TObjectList by default "OWNS" the objects it contains:
+  // if we clear the list, the objects contained get automatically destroyed
+  AllocatedInstances:= TObjectList<TCharacterSetECI>.Create;
+
+  TCharacterSetECI.addCharacterSet(  0, ['CP437']);
+  TCharacterSetECI.addCharacterSet(  1, ['ISO-8859-1','ISO8859_1']);
+  TCharacterSetECI.addCharacterSet(  2, ['CP437']);
+  TCharacterSetECI.addCharacterSet(  3, ['ISO-8859-1', 'ISO8859_1']);
+  TCharacterSetECI.addCharacterSet(  4, ['ISO-8859-2', 'ISO8859_2']);
+  TCharacterSetECI.addCharacterSet(  5, ['ISO-8859-3', 'ISO8859_3']);
+  TCharacterSetECI.addCharacterSet(  6, ['ISO-8859-4', 'ISO8859_4']);
+  TCharacterSetECI.addCharacterSet(  7, ['ISO-8859-5', 'ISO8859_5']);
+  TCharacterSetECI.addCharacterSet(  8, ['ISO-8859-6', 'ISO8859_6']);
+  TCharacterSetECI.addCharacterSet(  9, ['ISO-8859-7', 'ISO8859_7']);
+  TCharacterSetECI.addCharacterSet( 10, ['ISO-8859-8', 'ISO8859_8']);
+  TCharacterSetECI.addCharacterSet( 11, ['ISO-8859-9', 'ISO8859_9']);
+  TCharacterSetECI.addCharacterSet( 12, ['ISO-8859-4', 'ISO-8859-10', 'ISO8859_10']);
+  TCharacterSetECI.addCharacterSet( 13, ['ISO-8859-11', 'ISO8859_11']);
+  TCharacterSetECI.addCharacterSet( 15, ['ISO-8859-13', 'ISO8859_13']);
+  TCharacterSetECI.addCharacterSet($10, ['ISO-8859-1', 'ISO-8859-14', 'ISO8859_14']);
+  TCharacterSetECI.addCharacterSet($11, ['ISO-8859-15', 'ISO8859_15']);
+  TCharacterSetECI.addCharacterSet($12, ['ISO-8859-3', 'ISO-8859-16', 'ISO8859_16']);
+  TCharacterSetECI.addCharacterSet( 20, ['SJIS', 'Shift_JIS']);
+  TCharacterSetECI.addCharacterSet($15, ['WINDOWS-1250','CP1250']);
+  TCharacterSetECI.addCharacterSet($16, ['WINDOWS-1251','CP1251']);
+  TCharacterSetECI.addCharacterSet($17, ['WINDOWS-1252','CP1252']);
+  TCharacterSetECI.addCharacterSet($18, ['WINDOWS-1256', 'CP1256']);
+  TCharacterSetECI.addCharacterSet($19, ['UTF-16BE','UNICODEBIG']);
+  TCharacterSetECI.addCharacterSet($1A, ['UTF-8', 'UTF8']);
+  TCharacterSetECI.addCharacterSet($1B, ['US-ASCII']);
+  TCharacterSetECI.addCharacterSet(170, ['US-ASCII']);
+  TCharacterSetECI.addCharacterSet($1C, ['BIG5']);
+  TCharacterSetECI.addCharacterSet($1D, ['GB18030', 'GB2312', 'EUC_CN', 'GBK'] );
+  TCharacterSetECI.addCharacterSet( 30, ['EUC-KR', 'EUC_KR']);
+
+end;
+
+class procedure TCharacterSetECI.addCharacterSet(value: Integer; encodingNames: TArray<string>);
 var
   t: string;
   Eci: TCharacterSetECI;
 begin
   Eci := TCharacterSetECI.Create(value, encodingNames[0]);
-  TCharacterSetECI.VALUE_TO_ECI[value] := Eci;
+  TCharacterSetECI.VALUE_TO_ECI.AddOrSetValue(value,Eci);   // note : VALUE_TO_ECI[value] := Eci raises "key not found exception": it cant' be used for adding not existing values
 
   for t in encodingNames do
-  begin
-    TCharacterSetECI.NAME_TO_ECI[t] := Eci
-  end
-end;
-
-class procedure TCharacterSetECI.addCharacterSet(value: Integer;
-  encodingName: string);
-var
-  Eci: TCharacterSetECI;
-begin
-  Eci := TCharacterSetECI.Create(value, encodingName);
-  TCharacterSetECI.VALUE_TO_ECI[value] := Eci;
-  TCharacterSetECI.NAME_TO_ECI[encodingName] := Eci
+     TCharacterSetECI.NAME_TO_ECI.AddOrSetValue(t,Eci);
 end;
 
 class function TCharacterSetECI.getCharacterSetECIByName(name: string)

--- a/Lib/Classes/Common/DetectorResult.pas
+++ b/Lib/Classes/Common/DetectorResult.pas
@@ -25,22 +25,22 @@ type
   TDetectorResult = class
 
     FBits: TBitmatrix;
-    FPoints: TArray<TResultPoint>;
+    FPoints: TArray<IResultPoint>;
   private
     function get_Bits: TBitmatrix;
-    function get_Points: TArray<TResultPoint>;
+    function get_Points: TArray<IResultPoint>;
 
   public
-    constructor Create(bits: TBitmatrix; points: TArray<TResultPoint>);
+    constructor Create(bits: TBitmatrix; points: TArray<IResultPoint>);
     destructor Destroy; override;
     property bits: TBitmatrix read get_Bits;
-    property points: TArray<TResultPoint> read get_Points;
+    property points: TArray<IResultPoint> read get_Points;
   end;
 
 implementation
 
 constructor TDetectorResult.Create(bits: TBitmatrix;
-  points: TArray<TResultPoint>);
+  points: TArray<IResultPoint>);
 begin
   FBits := bits;
   FPoints := points
@@ -58,7 +58,7 @@ begin
   result := FBits;
 end;
 
-function TDetectorResult.get_Points: TArray<TResultPoint>;
+function TDetectorResult.get_Points: TArray<IResultPoint>;
 begin
   result := FPoints;
 end;

--- a/Lib/Classes/Common/ReadResult.pas
+++ b/Lib/Classes/Common/ReadResult.pas
@@ -30,7 +30,7 @@ type
     FText: string;
     FResultMetadata: TDictionary<TResultMetadataType, TObject>;
     FRawBytes: TArray<byte>;
-    FResultPoints: TArray<TResultPoint>;
+    FResultPoints: TArray<IResultPoint>;
     FBarcodeFormat: TBarcodeFormat;
 
   public
@@ -44,7 +44,7 @@ type
     /// identifying finder patterns or the corners of the barcode. The exact meaning is
     /// specific to the type of barcode that was decoded.
     /// </returns>
-    property ResultPoints: TArray<TResultPoint> read FResultPoints
+    property ResultPoints: TArray<IResultPoint> read FResultPoints
       write FResultPoints;
 
     property BarcodeFormat: TBarcodeFormat read FBarcodeFormat
@@ -54,7 +54,7 @@ type
       read FResultMetadata write FResultMetadata;
 
     constructor Create(Text: string; RawBytes: TArray<byte>;
-      ResultPoints: TArray<TResultPoint>; BarcodeFormat: TBarcodeFormat);
+      ResultPoints: TArray<IResultPoint>; BarcodeFormat: TBarcodeFormat);
 
     destructor Destroy(); override;
 
@@ -71,7 +71,7 @@ implementation
 { TReadResult }
 
 constructor TReadResult.Create(Text: string; RawBytes: TArray<byte>;
-  ResultPoints: TArray<TResultPoint>; BarcodeFormat: TBarcodeFormat);
+  ResultPoints: TArray<IResultPoint>; BarcodeFormat: TBarcodeFormat);
 begin
   if ((Text = '') and (RawBytes = nil)) then
   begin
@@ -88,12 +88,9 @@ end;
 
 destructor TReadResult.Destroy;
 var
-  ResultPoint: TResultPoint;
+  ResultPoint: IResultPoint;
 begin
-  for ResultPoint in ResultPoints do
-  begin
-    ResultPoint.Free;
-  end;
+  SetLength(FResultPoints,0);
 
   ResultPoints := nil;
   FRawBytes := nil;

--- a/Lib/Classes/Common/ResultPointImpl.pas
+++ b/Lib/Classes/Common/ResultPointImpl.pas
@@ -24,13 +24,14 @@ type
   protected
     constructor Create(const pX, pY: single);
   strict protected
-    destructor Destroy(); override;
     function Equals(other: IResultPoint): Boolean; reintroduce;
-    function GetHashCode(): Integer; override;
-    function ToString(): String; override;
 
     property x: single read GetX write SetX;
     property y: single read GetY write SetY;
+  public
+    destructor Destroy(); override;
+    function GetHashCode(): Integer; override;
+    function ToString(): String; override;
   end;
 
 

--- a/Lib/Classes/Common/ResultPointImpl.pas
+++ b/Lib/Classes/Common/ResultPointImpl.pas
@@ -1,0 +1,113 @@
+unit ResultPointImpl;
+
+interface
+uses sysutils,ResultPoint;
+
+
+  function NewResultPoint  (const pX, pY: single):IResultPoint;
+
+
+type
+  // this class must NOT be instantiated directly: it is declared in the interface section
+  // and not in the implementation only to allow the declaration of derived classes..
+  // that must too be accessed only via interfaces
+  TResultPointImpl = class(TInterfacedObject,IResultPoint)
+  strict private
+    Fx, Fy: single;
+    bytesX, bytesY: byteArray;
+    FToString: string;
+    function GetX: single;
+    function GetY: single;
+    procedure SetX(const Value: single);
+    procedure SetY(const Value: single);
+
+  protected
+    constructor Create(const pX, pY: single);
+  strict protected
+    destructor Destroy(); override;
+    function Equals(other: IResultPoint): Boolean; reintroduce;
+    function GetHashCode(): Integer; override;
+    function ToString(): String; override;
+
+    property x: single read GetX write SetX;
+    property y: single read GetY write SetY;
+  end;
+
+
+implementation
+uses MathUtils;
+
+
+constructor TResultPointImpl.Create(const pX, pY: single);
+begin
+  Fx := pX;
+  Fy := pY;
+  SetLength(bytesX,4);
+  SetLength(bytesY,4);
+  //bytesX := byteArray(pX);
+  //bytesY := byteArray(pY);
+end;
+
+destructor TResultPointImpl.Destroy;
+begin
+  bytesX := nil;
+  bytesY := nil;
+  inherited;
+end;
+
+function TResultPointImpl.Equals(other: IResultPoint): Boolean;
+begin
+  if (other = nil) then
+  begin
+    result := false;
+    Exit;
+  end;
+
+  result := ((other.x = Fx) and (other.y = Fy));
+end;
+
+function TResultPointImpl.GetHashCode: Integer;
+begin
+  result := 31 * ((bytesX[0] shl 24) + (bytesX[1] shl 16) + (bytesX[2] shl 8) +
+    bytesX[3]) + (bytesY[0] shl 24) + (bytesY[1] shl 16) + (bytesY[2] shl 8) +
+    bytesY[3];
+end;
+
+function TResultPointImpl.GetX: single;
+begin
+  result := Fx;
+end;
+
+function TResultPointImpl.GetY: single;
+begin
+  result := Fy;
+end;
+
+procedure TResultPointImpl.SetX(const Value: single);
+begin
+   Fx := value;
+end;
+
+procedure TResultPointImpl.SetY(const Value: single);
+begin
+  Fy := value;
+end;
+
+function TResultPointImpl.ToString: String;
+begin
+  if (FToString = '') then
+  begin
+    FToString := Format('(%g),(%g)', [Fx, Fy]);
+  end;
+
+  result := FToString;
+end;
+
+
+function NewResultPoint  (const pX, pY: single):IResultPoint;
+begin
+    result := TResultPointImpl.Create(px,py);
+end;
+
+
+end.

--- a/UnitTest/dUnitXTest.dpr
+++ b/UnitTest/dUnitXTest.dpr
@@ -62,7 +62,10 @@ uses
   Mode in '..\Lib\Classes\2D Barcodes\Decoder\Mode.pas',
   Datamask in '..\Lib\Classes\2D Barcodes\Decoder\Datamask.pas',
   ScanManager in '..\Lib\Classes\ScanManager.pas',
-  ITFReader in '..\Lib\Classes\1D Barcodes\ITFReader.pas';
+  ITFReader in '..\Lib\Classes\1D Barcodes\ITFReader.pas',
+  ResultPointImpl in '..\Lib\Classes\Common\ResultPointImpl.pas',
+  AlignmentPatternImpl in '..\Lib\Classes\2D Barcodes\Detector\AlignmentPatternImpl.pas',
+  FinderPatternImpl in '..\Lib\Classes\2D Barcodes\Detector\FinderPatternImpl.pas';
 
 var
   runner : ITestRunner;

--- a/aTestApp/aTestApp.dpr
+++ b/aTestApp/aTestApp.dpr
@@ -52,7 +52,10 @@ uses
   LuminanceSource in '..\Lib\Classes\Filtering\LuminanceSource.pas',
   RGBLuminanceSource in '..\Lib\Classes\Filtering\RGBLuminanceSource.Pas',
   ScanManager in '..\Lib\Classes\ScanManager.pas',
-  ITFReader in '..\Lib\Classes\1D Barcodes\ITFReader.pas';
+  ITFReader in '..\Lib\Classes\1D Barcodes\ITFReader.pas',
+  ResultPointImpl in '..\Lib\Classes\Common\ResultPointImpl.pas',
+  AlignmentPatternImpl in '..\Lib\Classes\2D Barcodes\Detector\AlignmentPatternImpl.pas',
+  FinderPatternImpl in '..\Lib\Classes\2D Barcodes\Detector\FinderPatternImpl.pas';
 
 {$R *.res}
 

--- a/aTestApp/main.fmx
+++ b/aTestApp/main.fmx
@@ -89,9 +89,19 @@ object MainForm: TMainForm
         Size.Width = 183.000000000000000000
         Size.Height = 44.000000000000000000
         Size.PlatformDefault = False
-        TabOrder = 2
+        TabOrder = 3
         Text = 'Start Camera'
         OnClick = btnStartCameraClick
+      end
+      object btnLoadFromFile: TButton
+        Align = Left
+        Position.X = 334.000000000000000000
+        Size.Width = 183.000000000000000000
+        Size.Height = 44.000000000000000000
+        Size.PlatformDefault = False
+        TabOrder = 2
+        Text = 'Load Image from File...'
+        OnClick = btnLoadFromFileClick
       end
     end
   end
@@ -99,5 +109,9 @@ object MainForm: TMainForm
     OnSampleBufferReady = CameraComponent1SampleBufferReady
     Left = 552
     Top = 88
+  end
+  object openDlg: TOpenDialog
+    Left = 448
+    Top = 232
   end
 end


### PR DESCRIPTION
The original C# code was heavily relying on the garbage collector when handling TResultPoint instances (and its derived classes TAligmentPattern and TFinderPattern).

Since, the only thing that handles automatic reference reference counting and deallocation under Win32/Win64 is Interfaces, I rewrote all the code that was using such classes in order to use the new interfaces I Intrdoduced, named IResultPoint, IAlignmentPattern and IFinderPattern, wich are now implemented by TInterfacedObect derived classes named TResultPointImpl, TAligmentPatternImpl and TFinderPatternImpl.  these three implementation classes are never used directly by the code.

I moved all "class methods" (those can't be declared inside interfaces) to a separate static classes named "TResultPointHelpers","TAlignmentPatternHelpers", etc... 

These helping classes do contain also the functions that allocate the underlying implementation class instances and return the appropriate interfaces to be used by the rest of the code.

 I also had to do a little workaround, to totally get rid of ALL memory leaks because I think I met a compiler bug  (see how I did modify function TFinderPatternFinder.selectBestPatterns): it seems that 

`self.PossibleCenters.Sort(TFurthestFromAverageComparator.Create(average))`

was not correctly handling the reference counting of the IComparer interface being created: the destructor of TFurthestFromAverageComparator was never called. the workaround was split the call in two statements: first I assign the interface to a local variable and then I pass the interface to TList.Sort. this seems to do the trick and automatic reference counting starts to work again. I experienced this with XE8, I hope this is fixed in most recent compilers.

Since now I am using reference counting, it is not necessary anymore to use the ".Clone" constructors I suggested to introduce in my previous contribution (that weren't completly solving the issue, anyway).

Oh, a little change I made to the test application: since I do not have a webcam on my workplace PC, I added a third button to load the barcode to be scanned from a file.
