### PR TITLE
TCharacterSetECI was never initialized correctly: it generated access…

### DIFF
--- a/Lib/Classes/2D Barcodes/Decoder/ZXing.QrCode.Internal.Mode.pas
+++ b/Lib/Classes/2D Barcodes/Decoder/ZXing.QrCode.Internal.Mode.pas
@@ -204,8 +204,7 @@ begin
     $3: Result := TMode.STRUCTURED_APPEND;
     $4: Result := TMode.BYTE;
     $5: Result := TMode.FNC1_FIRST_POSITION;
-    $6, // IS THIS "6" A TYPO? ECI should be 7, according to   ISO 18004:2006, 6.4.1, Table 2
-      $7: Result := TMode.ECI;
+    $7: Result := TMode.ECI;
     $8: Result := TMode.KANJI;
     $9: Result := TMode.FNC1_SECOND_POSITION;
     $D: Result := TMode.HANZI; // 0xD is defined in GBT 18284-2000, may not be supported in foreign country
@@ -223,7 +222,7 @@ begin
   then
      raise EArgumentException.Create('Character count doesn''t apply to this mode');
 
-       number := version.VersionNumber;
+  number := version.VersionNumber;
   if (number <= 9)
   then
      offset := 0

--- a/Lib/Classes/2D Barcodes/Decoder/ZXing.QrCode.Internal.Mode.pas
+++ b/Lib/Classes/2D Barcodes/Decoder/ZXing.QrCode.Internal.Mode.pas
@@ -204,7 +204,8 @@ begin
     $3: Result := TMode.STRUCTURED_APPEND;
     $4: Result := TMode.BYTE;
     $5: Result := TMode.FNC1_FIRST_POSITION;
-    $6: Result := TMode.ECI;
+    $6, // IS THIS "6" A TYPO? ECI should be 7, according to   ISO 18004:2006, 6.4.1, Table 2
+      $7: Result := TMode.ECI;
     $8: Result := TMode.KANJI;
     $9: Result := TMode.FNC1_SECOND_POSITION;
     $D: Result := TMode.HANZI; // 0xD is defined in GBT 18284-2000, may not be supported in foreign country
@@ -222,7 +223,7 @@ begin
   then
      raise EArgumentException.Create('Character count doesn''t apply to this mode');
 
-  number := version.VersionNumber;
+       number := version.VersionNumber;
   if (number <= 9)
   then
      offset := 0

--- a/Lib/Classes/2D Barcodes/Detector/ZXing.QrCode.Internal.FinderPatternFinder.pas
+++ b/Lib/Classes/2D Barcodes/Detector/ZXing.QrCode.Internal.FinderPatternFinder.pas
@@ -837,6 +837,7 @@ var
   totalModuleSize, average, size, stdDev, square, limit: Single;
   center, possibleCenter, pattern: TFinderPattern;
   startSize, i: Integer;
+  comparator: IComparer<TFinderPattern>;
 begin
   startSize := FPossibleCenters.Count;
   if (startSize < 3) then
@@ -858,8 +859,14 @@ begin
 
     average := totalModuleSize / startSize;
     stdDev := Sqrt((square / startSize) - (average * average));
-
-    FPossibleCenters.Sort(TFurthestFromAverageComparator.Create(average));
+    // this intermediate assignment is a workaround for old-gen compilers
+    // that are not deallocating TFurthestFromAverageComparator instance
+    // (bug verified on XE8: just declare a destructor Destroy override
+    // in TFurthestFromAverageComparator put a breakpoint in it and see
+    // that the destructor never gets called if  you don't use this intermediate
+    // assignment)
+    comparator :=  TFurthestFromAverageComparator.Create(average);
+    FPossibleCenters.Sort(comparator);
     limit := System.Math.Max((0.2 * average), stdDev);
     i := 0;
     while (((i < FPossibleCenters.Count) and
@@ -885,7 +892,14 @@ begin
     end;
 
     average := totalModuleSize / FPossibleCenters.Count;
-    FPossibleCenters.Sort(TCenterComparator.Create(average));
+    // this intermediate assignment is a workaround for old-gen compilers
+    // that are not deallocating TCenterComparator instance
+    // (bug verified on XE8: just declare a destructor Destroy override in
+    // TCenterComparator,put a breakpoint in it and see that the destructor
+    // never gets called if  you don't use this intermediate assignment)
+    comparator :=  TCenterComparator.Create(average);
+
+    FPossibleCenters.Sort( comparator );
 
     // if (PossibleCenters.Count > 4) then
     // begin

--- a/Lib/Classes/Common/CharacterSetECI.pas
+++ b/Lib/Classes/Common/CharacterSetECI.pas
@@ -33,18 +33,22 @@ type
   end;
 
   TCharacterSetECI = class sealed(TECI)
-  private
+  strict private
     FEncodingName: string;
     class var NAME_TO_ECI: TDictionary<string, TCharacterSetECI>;
     class var VALUE_TO_ECI: TDictionary<Integer, TCharacterSetECI>;
+    ///<summary>
+    /// this objectlist is just for doing proper deallocation of TCharacterSetECI instances under Win32/Win64,
+    /// without having to mess with TInterfacedObject. Since instances are meant to exist for the whole program life, there's no need of doing
+    /// anything much more complicated than this.
+    /// </summary>
+    class var AllocatedInstances:TObjectList<TCharacterSetECI>;
 
-    constructor Create; overload;
+    class constructor Create;
     constructor Create(value: Integer; encodingName: string); overload;
+    class destructor Destroy;
 
-    class procedure addCharacterSet(value: Integer; encodingName: string);
-      overload; static;
-    class procedure addCharacterSet(value: Integer;
-      encodingNames: TArray<string>); overload; static;
+    class procedure addCharacterSet(value: Integer;  encodingNames: TArray<string>); static;
 
   public
 
@@ -86,91 +90,73 @@ end;
 constructor TCharacterSetECI.Create(value: Integer; encodingName: string);
 begin
   inherited Create(value);
-  FEncodingName := encodingName
+  FEncodingName := encodingName;
+  AllocatedInstances.Add(self); // add the instance to the global list of all created instances
 end;
 
-constructor TCharacterSetECI.Create;
+class destructor TCharacterSetECI.Destroy;
 begin
-  TCharacterSetECI.addCharacterSet(0, 'CP437');
-  TCharacterSetECI.addCharacterSet(1, TArray<string>.Create('ISO-8859-1',
-    'ISO8859_1'));
-  TCharacterSetECI.addCharacterSet(2, 'CP437');
-  TCharacterSetECI.addCharacterSet(3, TArray<string>.Create('ISO-8859-1',
-    'ISO8859_1'));
-  TCharacterSetECI.addCharacterSet(4, TArray<string>.Create('ISO-8859-2',
-    'ISO8859_2'));
-  TCharacterSetECI.addCharacterSet(5, TArray<string>.Create('ISO-8859-3',
-    'ISO8859_3'));
-  TCharacterSetECI.addCharacterSet(6, TArray<string>.Create('ISO-8859-4',
-    'ISO8859_4'));
-  TCharacterSetECI.addCharacterSet(7, TArray<string>.Create('ISO-8859-5',
-    'ISO8859_5'));
-  TCharacterSetECI.addCharacterSet(8, TArray<string>.Create('ISO-8859-6',
-    'ISO8859_6'));
-  TCharacterSetECI.addCharacterSet(9, TArray<string>.Create('ISO-8859-7',
-    'ISO8859_7'));
-  TCharacterSetECI.addCharacterSet(10, TArray<string>.Create('ISO-8859-8',
-    'ISO8859_8'));
-  TCharacterSetECI.addCharacterSet(11, TArray<string>.Create('ISO-8859-9',
-    'ISO8859_9'));
-  TCharacterSetECI.addCharacterSet(12, TArray<string>.Create('ISO-8859-4',
-    'ISO-8859-10', 'ISO8859_10'));
-  TCharacterSetECI.addCharacterSet(13, TArray<string>.Create('ISO-8859-11',
-    'ISO8859_11'));
-  TCharacterSetECI.addCharacterSet(15, TArray<string>.Create('ISO-8859-13',
-    'ISO8859_13'));
-  TCharacterSetECI.addCharacterSet($10, TArray<string>.Create('ISO-8859-1',
-    'ISO-8859-14', 'ISO8859_14'));
-  TCharacterSetECI.addCharacterSet($11, TArray<string>.Create('ISO-8859-15',
-    'ISO8859_15'));
-  TCharacterSetECI.addCharacterSet($12, TArray<string>.Create('ISO-8859-3',
-    'ISO-8859-16', 'ISO8859_16'));
-  TCharacterSetECI.addCharacterSet(20, TArray<string>.Create('SJIS',
-    'Shift_JIS'));
-  TCharacterSetECI.addCharacterSet($15, TArray<string>.Create('WINDOWS-1250',
-    'CP1250'));
-  TCharacterSetECI.addCharacterSet($16, TArray<string>.Create('WINDOWS-1251',
-    'CP1251'));
-  TCharacterSetECI.addCharacterSet($17, TArray<string>.Create('WINDOWS-1252',
-    'CP1252'));
-  TCharacterSetECI.addCharacterSet($18, TArray<string>.Create('WINDOWS-1256',
-    'CP1256'));
-  TCharacterSetECI.addCharacterSet($19, TArray<string>.Create('UTF-16BE',
-    'UNICODEBIG'));
-  TCharacterSetECI.addCharacterSet($1A, TArray<string>.Create('UTF-8', 'UTF8'));
-  TCharacterSetECI.addCharacterSet($1B, 'US-ASCII');
-  TCharacterSetECI.addCharacterSet(170, 'US-ASCII');
-  TCharacterSetECI.addCharacterSet($1C, 'BIG5');
-  TCharacterSetECI.addCharacterSet($1D, TArray<string>.Create('GB18030',
-    'GB2312', 'EUC_CN', 'GBK'));
-  TCharacterSetECI.addCharacterSet(30, TArray<string>.Create('EUC-KR',
-    'EUC_KR'))
+   NAME_TO_ECI.Free;
+   VALUE_TO_ECI.Free;
+
+   if  AllocatedInstances<>nil then begin
+      AllocatedInstances.Clear;
+      AllocatedInstances.Free;
+end;
 
 end;
 
-class procedure TCharacterSetECI.addCharacterSet(value: Integer;
-  encodingNames: TArray<string>);
+class constructor TCharacterSetECI.Create;
+begin
+  NAME_TO_ECI:=TDictionary<string, TCharacterSetECI>.Create;
+  VALUE_TO_ECI:=TDictionary<Integer, TCharacterSetECI>.Create;
+  // under Win32/64 TObjectList by default "OWNS" the objects it contains:
+  // if we clear the list, the objects contained get automatically destroyed
+  AllocatedInstances:= TObjectList<TCharacterSetECI>.Create;
+
+  TCharacterSetECI.addCharacterSet(  0, ['CP437']);
+  TCharacterSetECI.addCharacterSet(  1, ['ISO-8859-1','ISO8859_1']);
+  TCharacterSetECI.addCharacterSet(  2, ['CP437']);
+  TCharacterSetECI.addCharacterSet(  3, ['ISO-8859-1', 'ISO8859_1']);
+  TCharacterSetECI.addCharacterSet(  4, ['ISO-8859-2', 'ISO8859_2']);
+  TCharacterSetECI.addCharacterSet(  5, ['ISO-8859-3', 'ISO8859_3']);
+  TCharacterSetECI.addCharacterSet(  6, ['ISO-8859-4', 'ISO8859_4']);
+  TCharacterSetECI.addCharacterSet(  7, ['ISO-8859-5', 'ISO8859_5']);
+  TCharacterSetECI.addCharacterSet(  8, ['ISO-8859-6', 'ISO8859_6']);
+  TCharacterSetECI.addCharacterSet(  9, ['ISO-8859-7', 'ISO8859_7']);
+  TCharacterSetECI.addCharacterSet( 10, ['ISO-8859-8', 'ISO8859_8']);
+  TCharacterSetECI.addCharacterSet( 11, ['ISO-8859-9', 'ISO8859_9']);
+  TCharacterSetECI.addCharacterSet( 12, ['ISO-8859-4', 'ISO-8859-10', 'ISO8859_10']);
+  TCharacterSetECI.addCharacterSet( 13, ['ISO-8859-11', 'ISO8859_11']);
+  TCharacterSetECI.addCharacterSet( 15, ['ISO-8859-13', 'ISO8859_13']);
+  TCharacterSetECI.addCharacterSet($10, ['ISO-8859-1', 'ISO-8859-14', 'ISO8859_14']);
+  TCharacterSetECI.addCharacterSet($11, ['ISO-8859-15', 'ISO8859_15']);
+  TCharacterSetECI.addCharacterSet($12, ['ISO-8859-3', 'ISO-8859-16', 'ISO8859_16']);
+  TCharacterSetECI.addCharacterSet( 20, ['SJIS', 'Shift_JIS']);
+  TCharacterSetECI.addCharacterSet($15, ['WINDOWS-1250','CP1250']);
+  TCharacterSetECI.addCharacterSet($16, ['WINDOWS-1251','CP1251']);
+  TCharacterSetECI.addCharacterSet($17, ['WINDOWS-1252','CP1252']);
+  TCharacterSetECI.addCharacterSet($18, ['WINDOWS-1256', 'CP1256']);
+  TCharacterSetECI.addCharacterSet($19, ['UTF-16BE','UNICODEBIG']);
+  TCharacterSetECI.addCharacterSet($1A, ['UTF-8', 'UTF8']);
+  TCharacterSetECI.addCharacterSet($1B, ['US-ASCII']);
+  TCharacterSetECI.addCharacterSet(170, ['US-ASCII']);
+  TCharacterSetECI.addCharacterSet($1C, ['BIG5']);
+  TCharacterSetECI.addCharacterSet($1D, ['GB18030', 'GB2312', 'EUC_CN', 'GBK'] );
+  TCharacterSetECI.addCharacterSet( 30, ['EUC-KR', 'EUC_KR']);
+
+end;
+
+class procedure TCharacterSetECI.addCharacterSet(value: Integer; encodingNames: TArray<string>);
 var
   t: string;
   Eci: TCharacterSetECI;
 begin
   Eci := TCharacterSetECI.Create(value, encodingNames[0]);
-  TCharacterSetECI.VALUE_TO_ECI[value] := Eci;
+  TCharacterSetECI.VALUE_TO_ECI.AddOrSetValue(value,Eci);   // note : VALUE_TO_ECI[value] := Eci raises "key not found exception": it cant' be used for adding not existing values
 
   for t in encodingNames do
-  begin
-    TCharacterSetECI.NAME_TO_ECI[t] := Eci
-  end
-end;
-
-class procedure TCharacterSetECI.addCharacterSet(value: Integer;
-  encodingName: string);
-var
-  Eci: TCharacterSetECI;
-begin
-  Eci := TCharacterSetECI.Create(value, encodingName);
-  TCharacterSetECI.VALUE_TO_ECI[value] := Eci;
-  TCharacterSetECI.NAME_TO_ECI[encodingName] := Eci
+     TCharacterSetECI.NAME_TO_ECI.AddOrSetValue(t,Eci);
 end;
 
 class function TCharacterSetECI.getCharacterSetECIByName(name: string)

--- a/Lib/Classes/ScanManager.pas
+++ b/Lib/Classes/ScanManager.pas
@@ -136,11 +136,11 @@ var
   HybridBinarizer: THybridBinarizer;
   BinaryBitmap: TBinaryBitmap;
 begin
+  InvLuminanceSource := nil;
+  LuminanceSource := nil;
+  HybridBinarizer := nil;
+  BinaryBitmap := nil;
   try
-    InvLuminanceSource := nil;
-    LuminanceSource := nil;
-    HybridBinarizer := nil;
-    BinaryBitmap := nil;
 
     LuminanceSource := TRGBLuminanceSource.CreateFromBitmap(pBitmapForScan,
       pBitmapForScan.Width, pBitmapForScan.Height);

--- a/aTestApp/main.fmx
+++ b/aTestApp/main.fmx
@@ -40389,9 +40389,19 @@ object MainForm: TMainForm
         Size.Width = 183.000000000000000000
         Size.Height = 48.000000000000000000
         Size.PlatformDefault = False
-        TabOrder = 2
+        TabOrder = 5
         Text = 'Start Camera'
         OnClick = btnStartCameraClick
+      end
+      object btnLoadFromFile: TButton
+        Align = Left
+        Position.X = 334.000000000000000000
+        Size.Width = 235.000000000000000000
+        Size.Height = 48.000000000000000000
+        Size.PlatformDefault = False
+        TabOrder = 2
+        Text = 'Load Image from File...'
+        OnClick = btnLoadFromFileClick
       end
       object Button1: TButton
         Align = Right
@@ -40427,6 +40437,10 @@ object MainForm: TMainForm
   object CameraComponent1: TCameraComponent
     OnSampleBufferReady = CameraComponent1SampleBufferReady
     Left = 544
+    Top = 96
+  end
+  object openDlg: TOpenDialog
+    Left = 664
     Top = 96
   end
 end


### PR DESCRIPTION
I am starting to apply to branch 3.0 the bugfixes I already applied to master branch.
I started by fixing TCharacterSetECI.

 As I said, its "class var" members were never initialized because what should be a "class constructor" was declared as a simple "instance constructor", so it was not executed. Moreover it contained bugs that were never experienced since the code was never run.

A QRCode that causess the access violations is the one I am attaching here.
 I must say that this barcode triggers another error (that must be addressed) before entering the code that fires the access violations.

 To have this barcode recognized I had to work around this other bug by adding the "7" case in this method inside ZXing.QrCode.Internal.Mode:

```
 class function TMode.forBits(const bits: Integer): TMode;
begin
  case bits of
    $0: Result := TMode.TERMINATOR;
    $1: Result := TMode.NUMERIC;
    $2: Result := TMode.ALPHANUMERIC;
    $3: Result := TMode.STRUCTURED_APPEND;
    $4: Result := TMode.BYTE;
    $5: Result := TMode.FNC1_FIRST_POSITION;
    $6,$7: Result := TMode.ECI; // $7 added as a quick and clueless workaround
    $8: Result := TMode.KANJI;
    $9: Result := TMode.FNC1_SECOND_POSITION;
    $D: Result := TMode.HANZI; // 0xD is defined in GBT 18284-2000, may not be supported in foreign country
    else
       raise EArgumentException.Create('Invalid arguments');
  end;
end;
```

Since I don't know the internals the QRCodes specs I am NOT incuding the above fix in this pull request: I am just reporting it in this comment. I am just suggesting you to add the above $7 case just to see the access violations caused by TCharacterSetECI. I hope you have a better understanding of the QRCode standards and that you know which is the correct way of interpreting that "7" value.

![0175649016300000001](https://cloud.githubusercontent.com/assets/5736859/17971468/4819373e-6adb-11e6-82ba-27a845a9091f.jpg)
