### PR TITLE
Fixed almost all memory leaks under Win32/Win64

### DIFF
--- a/Lib/Classes/1D Barcodes/ZXing.OneD.Code93Reader.pas
+++ b/Lib/Classes/1D Barcodes/ZXing.OneD.Code93Reader.pas
@@ -46,7 +46,7 @@ type
       checkPosition, weightMax: Integer): boolean;
     class function decodeExtended(encoded: TStringBuilder): string; static;
 
-    function findAsteriskPattern(row: TBitArray): TArray<Integer>;
+    function findAsteriskPattern(row: IBitArray): TArray<Integer>;
     class function patternToChar(pattern: Integer; var c: Char)
       : boolean; static;
     class function toPattern(counters: TArray<Integer>): Integer; static;
@@ -65,7 +65,7 @@ type
     constructor Create;
     destructor Destroy; override;
 
-    function decodeRow(const rowNumber: Integer; const row: TBitArray;
+    function decodeRow(const rowNumber: Integer; const row: IBitArray;
       const hints: TDictionary<TDecodeHintType, TObject>): TReadResult; override;
   end;
 
@@ -261,7 +261,7 @@ begin
 
 end;
 
-function TCode93Reader.decodeRow(const rowNumber: Integer; const row: TBitArray;
+function TCode93Reader.decodeRow(const rowNumber: Integer; const row: IBitArray;
   const hints: TDictionary<TDecodeHintType, TObject>): TReadResult;
 var
   decodedChar: Char;
@@ -274,8 +274,8 @@ var
   Left, Right: Single;
   resultPointCallback: TResultPointCallback;
   obj: TObject;
-  resultPoints: TArray<TResultPoint>;
-  resultPointLeft, resultPointRight: TResultPoint;
+  resultPoints: TArray<IResultPoint>;
+  resultPointLeft, resultPointRight: IResultPoint;
 begin
   for index := 0 to length(counters) - 1 do
     counters[index] := 0;
@@ -358,9 +358,11 @@ begin
   Left := (start[1] + start[0]) div 2;
   Right := (lastStart + lastPatternSize) div 2;
 
-  resultPointLeft := TResultPoint.Create(Left, rowNumber);
-  resultPointRight := TResultPoint.Create(Right, rowNumber);
+  resultPointLeft := TResultPointHelpers.CreateResultPoint(Left, rowNumber);
+  resultPointRight := TResultPointHelpers.CreateResultPoint(Right, rowNumber);
   resultPoints := [resultPointLeft, resultPointRight];
+
+  resultPointCallback := nil; // it is a local variable: it doesn't get NIL as default value, and the following ifs do not assign a value for all possible cases
 
   if ((hints = nil) or
       (not hints.ContainsKey(TDecodeHintType.NEED_RESULT_POINT_CALLBACK)))
@@ -384,7 +386,7 @@ begin
     TBarcodeFormat.CODE_39);
 end;
 
-function TCode93Reader.findAsteriskPattern(row: TBitArray): TArray<Integer>;
+function TCode93Reader.findAsteriskPattern(row: IBitArray): TArray<Integer>;
 var
   i, l, patternStart, patternLength, width, counterPosition, rowOffset,
     index: Integer;

--- a/Lib/Classes/1D Barcodes/ZXing.OneD.EAN13Reader.pas
+++ b/Lib/Classes/1D Barcodes/ZXing.OneD.EAN13Reader.pas
@@ -98,7 +98,7 @@ type
     /// <returns>
     /// horizontal offset of first pixel after the "middle" that was decoded or -1 if decoding could not complete successfully
     /// </returns>
-    class function decodeMiddle(const row: TBitArray;
+    class function decodeMiddle(const row: IBitArray;
       const startRange: TArray<Integer>;
       const resultString: TStringBuilder): Integer; override;
   public
@@ -129,7 +129,7 @@ begin
   inherited;
 end;
 
-class function TEAN13Reader.decodeMiddle(const row: TBitArray;
+class function TEAN13Reader.decodeMiddle(const row: IBitArray;
   const startRange: TArray<Integer>;
   const resultString: TStringBuilder): Integer;
 var

--- a/Lib/Classes/1D Barcodes/ZXing.OneD.UPCEANExtension2Support.pas
+++ b/Lib/Classes/1D Barcodes/ZXing.OneD.UPCEANExtension2Support.pas
@@ -46,7 +46,7 @@ type
     class procedure InitializeClass; static;
     class procedure FinalizeClass; static;
 
-    class function decodeMiddle(const row: TBitArray;
+    class function decodeMiddle(const row: IBitArray;
       const startRange: TArray<Integer>;
       const resultString: TStringBuilder): Integer;
 
@@ -58,7 +58,7 @@ type
     class function parseExtensionString(const raw: String):
       TDictionary<TResultMetadataType, TObject>; static;
   public
-    class function decodeRow(const rowNumber: Integer; const row: TBitArray;
+    class function decodeRow(const rowNumber: Integer; const row: IBitArray;
       const extensionStartRange: TArray<Integer>): TReadResult;
   end;
 
@@ -82,14 +82,14 @@ begin
 end;
 
 class function TUPCEANExtension2Support.decodeRow(const rowNumber: Integer;
-  const row: TBitArray; const extensionStartRange: TArray<Integer>): TReadResult;
+  const row: IBitArray; const extensionStartRange: TArray<Integer>): TReadResult;
 var
   res : TStringBuilder;
   ending : Integer;
   resultString : String;
   extensionResult : TReadResult;
   extensionData : TDictionary<TResultMetadataType, TObject>;
-  resultPoints : TArray<TResultPoint>;
+  resultPoints : TArray<IResultPoint>;
 begin
   Result := nil;
 
@@ -103,9 +103,9 @@ begin
   resultString := Result.ToString;
   extensionData := TUPCEANExtension2Support.parseExtensionString(resultString);
 
-  resultPoints := TArray<TResultPoint>.Create(
-    TResultPoint.Create((extensionStartRange[0] + extensionStartRange[1]) div 2, rowNumber),
-    TResultPoint.Create(ending, rowNumber));
+  resultPoints := TArray<IResultPoint>.Create(
+    TResultPointHelpers.CreateResultPoint((extensionStartRange[0] + extensionStartRange[1]) div 2, rowNumber),
+    TResultPointHelpers.CreateResultPoint(ending, rowNumber));
 
   extensionResult := TReadResult.Create(resultString, nil, resultPoints, TBarcodeFormat.UPC_EAN_EXTENSION);
   if (extensionData <> nil)
@@ -115,7 +115,7 @@ begin
   Result := extensionResult;
 end;
 
-class function TUPCEANExtension2Support.decodeMiddle(const row: TBitArray;
+class function TUPCEANExtension2Support.decodeMiddle(const row: IBitArray;
   const startRange: TArray<Integer>; const resultString: TStringBuilder): Integer;
 var
   bestMatch: Integer;

--- a/Lib/Classes/1D Barcodes/ZXing.OneD.UPCEANExtension5Support.pas
+++ b/Lib/Classes/1D Barcodes/ZXing.OneD.UPCEANExtension5Support.pas
@@ -48,7 +48,7 @@ type
     class procedure InitializeClass; static;
     class procedure FinalizeClass; static;
 
-    class function decodeMiddle(const row: TBitArray;
+    class function decodeMiddle(const row: IBitArray;
       const startRange: TArray<Integer>;
       const resultString: TStringBuilder): Integer;
 
@@ -68,7 +68,7 @@ type
 
     class function parseExtension5String(const raw: String): String; static;
   public
-    class function decodeRow(const rowNumber: Integer; const row: TBitArray;
+    class function decodeRow(const rowNumber: Integer; const row: IBitArray;
       const extensionStartRange: TArray<Integer>): TReadResult;
   end;
 
@@ -95,13 +95,13 @@ begin
 end;
 
 class function TUPCEANExtension5Support.decodeRow(const rowNumber: Integer;
-  const row: TBitArray; const extensionStartRange: TArray<Integer>): TReadResult;
+  const row: IBitArray; const extensionStartRange: TArray<Integer>): TReadResult;
 var
   res : TStringBuilder;
   ending : Integer;
   resultString : String;
   extensionData : TDictionary<TResultMetadataType, TObject>;
-  resultPoints : TArray<TResultPoint>;
+  resultPoints : TArray<IResultPoint>;
   extensionResult : TReadResult;
 begin
   Result := nil;
@@ -115,9 +115,9 @@ begin
 
   resultString := res.ToString;
   extensionData := parseExtensionString(resultString);
-  resultPoints := TArray<TResultPoint>.Create(
-    TResultPoint.Create((extensionStartRange[0] + extensionStartRange[1]) div 2, rowNumber),
-    TResultPoint.Create(ending, rowNumber));
+  resultPoints := TArray<IResultPoint>.Create(
+    TResultPointHelpers.CreateResultPoint((extensionStartRange[0] + extensionStartRange[1]) div 2, rowNumber),
+    TResultPointHelpers.CreateResultPoint(ending, rowNumber));
 
   extensionResult := TReadResult.Create(resultString, nil, resultPoints, TBarcodeFormat.UPC_EAN_EXTENSION);
   if (extensionData <> nil)
@@ -127,7 +127,7 @@ begin
   Result := extensionResult;
 end;
 
-class function TUPCEANExtension5Support.decodeMiddle(const row: TBitArray;
+class function TUPCEANExtension5Support.decodeMiddle(const row: IBitArray;
   const startRange: TArray<Integer>; const resultString: TStringBuilder): Integer;
 var
   bestMatch: Integer;

--- a/Lib/Classes/1D Barcodes/ZXing.OneD.UPCEANExtensionSupport.pas
+++ b/Lib/Classes/1D Barcodes/ZXing.OneD.UPCEANExtensionSupport.pas
@@ -47,7 +47,7 @@ type
     class procedure InitializeClass; static;
     class procedure FinalizeClass; static;
   public
-    function decodeRow(const rowNumber: Integer; const row: TBitArray;
+    function decodeRow(const rowNumber: Integer; const row: IBitArray;
       const rowOffset: Integer): TReadResult;
   end;
 
@@ -73,7 +73,7 @@ begin
 end;
 
 function TUPCEANExtensionSupport.decodeRow(const rowNumber: Integer;
-  const row: TBitArray; const rowOffset: Integer): TReadResult;
+  const row: IBitArray; const rowOffset: Integer): TReadResult;
 var
   extensionStartRange: TArray<Integer>;
   res : TReadResult;

--- a/Lib/Classes/1D Barcodes/ZXing.OneD.UPCEANReader.pas
+++ b/Lib/Classes/1D Barcodes/ZXing.OneD.UPCEANReader.pas
@@ -57,7 +57,7 @@ type
     /// searched for as a pattern
     /// <param name="counters">array of counters, as long as pattern, to re-use</param>
     /// <returns>start/end horizontal offset of guard pattern, as an array of two ints</returns>
-    class function findGuardPattern(const row: TBitArray;
+    class function findGuardPattern(const row: IBitArray;
       rowOffset: Integer; const whiteFirst: Boolean;
       const pattern: TArray<Integer>;
       counters: TArray<Integer>): TArray<Integer>; overload;
@@ -103,7 +103,7 @@ type
     /// <param name="startRange">start/end offset of start guard pattern</param>
     /// <param name="resultString"><see cref="StringBuilder" />to append decoded chars to</param>
     /// <returns>horizontal offset of first pixel after the "middle" that was decoded or -1 if decoding could not complete successfully</returns>
-    class function decodeMiddle(const row: TBitArray;
+    class function decodeMiddle(const row: IBitArray;
       const startRange: TArray<Integer>;
       const resultString: TStringBuilder): Integer; virtual; abstract;
 
@@ -113,7 +113,7 @@ type
     /// <param name="row">The row.</param>
     /// <param name="endStart">The end start.</param>
     /// <returns></returns>
-    class function decodeEnd(const row: TBitArray;
+    class function decodeEnd(const row: IBitArray;
       const endStart: Integer): TArray<Integer>; virtual;
 
     /// <summary>
@@ -141,9 +141,9 @@ type
     function BarcodeFormat: TBarcodeFormat; virtual; abstract;
 
     class function findStartGuardPattern(
-      const row: TBitArray): TArray<Integer>; static;
+      const row: IBitArray): TArray<Integer>; static;
 
-    class function findGuardPattern(const row: TBitArray;
+    class function findGuardPattern(const row: IBitArray;
       const rowOffset: Integer; const whiteFirst: Boolean;
       const pattern: TArray<Integer>): TArray<Integer>; overload;
 
@@ -157,7 +157,7 @@ type
     /// for the digits 0-9 are used, and this indicates the encodings for 0 to 9 that should
     /// be used
     /// <returns>horizontal offset of first pixel beyond the decoded digit</returns>
-    class function decodeDigit(const row: TBitArray; const counters: TArray<Integer>;
+    class function decodeDigit(const row: IBitArray; const counters: TArray<Integer>;
       const rowOffset: Integer; const patterns: TArray<TArray<Integer>>;
       var digit: Integer): Boolean;
 
@@ -171,7 +171,7 @@ type
     /// <returns>
     ///   <see cref="TReadResult"/>containing encoded string and start/end of barcode or null, if an error occurs or barcode cannot be found
     /// </returns>
-    function decodeRow(const rowNumber: Integer; const row: TBitArray;
+    function decodeRow(const rowNumber: Integer; const row: IBitArray;
       const hints: TDictionary<TDecodeHintType, TObject>): TReadResult;
       overload; override;
 
@@ -185,7 +185,7 @@ type
     /// <param name="startGuardRange">start/end column where the opening start pattern was found</param>
     /// <param name="hints">optional hints that influence decoding</param>
     /// <returns><see cref="TReadResult"/> encapsulating the result of decoding a barcode in the row</returns>
-    function decodeRow(const rowNumber: Integer; const row: TBitArray;
+    function decodeRow(const rowNumber: Integer; const row: IBitArray;
       const startGuardRange: TArray<Integer>;
       const hints: TDictionary<TDecodeHintType, TObject>): TReadResult;
       reintroduce; overload;
@@ -303,14 +303,14 @@ begin
   Result := ((sum mod 10) = 0);
 end;
 
-class function TUPCEANReader.decodeEnd(const row: TBitArray;
+class function TUPCEANReader.decodeEnd(const row: IBitArray;
    const endStart: Integer): TArray<Integer>;
  begin
    Result := findGuardPattern(row, endStart, false, START_END_PATTERN);
 end;
 
 class function TUPCEANReader.findStartGuardPattern(
-  const row: TBitArray): TArray<Integer>;
+  const row: IBitArray): TArray<Integer>;
 var
   foundStart: Boolean;
   startRange,
@@ -349,7 +349,7 @@ begin
   Result := startRange;
 end;
 
-class function TUPCEANReader.findGuardPattern(const row: TBitArray;
+class function TUPCEANReader.findGuardPattern(const row: IBitArray;
   const rowOffset: Integer; const whiteFirst: Boolean;
   const pattern: TArray<Integer>): TArray<Integer>;
 var
@@ -360,7 +360,7 @@ begin
   Result := findGuardPattern(row, rowOffset, whiteFirst, pattern, counters);
 end;
 
-class function TUPCEANReader.findGuardPattern(const row: TBitArray;
+class function TUPCEANReader.findGuardPattern(const row: IBitArray;
   rowOffset: Integer; const whiteFirst: Boolean;
   const pattern: TArray<Integer>;
   counters: TArray<Integer>): TArray<Integer>;
@@ -414,7 +414,7 @@ begin
   end;
 end;
 
-class function TUPCEANReader.decodeDigit(const row: TBitArray;
+class function TUPCEANReader.decodeDigit(const row: IBitArray;
   const counters: TArray<Integer>; const rowOffset: Integer;
   const patterns: TArray<TArray<Integer>>; var digit: Integer): Boolean;
 var
@@ -447,13 +447,13 @@ begin
   Result := (digit >= 0);
 end;
 
-function TUPCEANReader.decodeRow(const rowNumber: Integer; const row: TBitArray;
+function TUPCEANReader.decodeRow(const rowNumber: Integer; const row: IBitArray;
   const hints: TDictionary<TDecodeHintType, TObject>): TReadResult;
 begin
   Result := decodeRow(rowNumber, row, findStartGuardPattern(row), hints);
 end;
 
-function TUPCEANReader.decodeRow(const rowNumber: Integer; const row: TBitArray;
+function TUPCEANReader.decodeRow(const rowNumber: Integer; const row: IBitArray;
   const startGuardRange: TArray<Integer>;
   const hints: TDictionary<TDecodeHintType, TObject>): TReadResult;
 var
@@ -464,11 +464,11 @@ var
   ending,
   quietEnd : Integer;
   endRange : TArray<Integer>;
-  resultPoints : TArray<TResultPoint>;
+  resultPoints : TArray<IResultPoint>;
   left, right : Single;
   resultPointCallback: TResultPointCallback;
   obj: TObject;
-  resPoint : TResultPoint;
+  resPoint : IResultPoint;
   decodeResult,
   extensionResult : TReadResult;
   format : TBarcodeFormat;
@@ -498,12 +498,8 @@ begin
 
   if Assigned(resultPointCallback) then
   begin
-    resPoint := TResultPoint.Create(endStart, rowNumber);
-    try
-      resultPointCallback(resPoint);
-    finally
-      resPoint.Free;
-    end;
+    resPoint := TResultPointHelpers.CreateResultPoint(endStart, rowNumber);
+    resultPointCallback(resPoint);
   end;
 
   endRange := decodeEnd(row, endStart);
@@ -513,12 +509,8 @@ begin
 
   if Assigned(resultPointCallback) then
   begin
-    resPoint := TResultPoint.Create((endRange[0] + endRange[1]) div 2, rowNumber);
-    try
-      resultPointCallback(resPoint);
-    finally
-      resPoint.Free;
-    end;
+    resPoint := TResultPointHelpers.CreateResultPoint((endRange[0] + endRange[1]) div 2, rowNumber);
+    resultPointCallback(resPoint);
   end;
 
   ending := endRange[1];
@@ -536,8 +528,8 @@ begin
   left := ((startGuardRange[1] + startGuardRange[0]) div 2);
   right := ((endRange[1] + endRange[0]) div 2);
   format := BarcodeFormat;
-  resultPoints := TArray<TResultPoint>.Create(TResultPoint.Create(left, rowNumber),
-                                              TResultPoint.Create(right, rowNumber));
+  resultPoints := TArray<IResultPoint>.Create(TResultPointHelpers.CreateResultPoint(left, rowNumber),
+                                              TResultPointHelpers.CreateResultPoint(right, rowNumber));
   decodeResult := TReadResult.Create(resultString, nil, resultPoints, format);
   extensionResult := extensionReader.decodeRow(rowNumber, row, endRange[1]);
   if (extensionResult <> nil) then

--- a/Lib/Classes/2D Barcodes/Decoder/ZXing.Datamatrix.Internal.DecodedBitStreamParser.pas
+++ b/Lib/Classes/2D Barcodes/Decoder/ZXing.Datamatrix.Internal.DecodedBitStreamParser.pas
@@ -75,10 +75,8 @@ class function TDecodedBitStreamParser.decode(bytes: TArray<Byte>)
 var
   bits: TBitSource;
   res, resultTrailer: TStringBuilder;
-  bs: TArray<Byte>;
   byteSegments: TList<TArray<Byte>>;
   mode: TMode;
-  i: Integer;
 
 begin
   bits := TBitSource.Create(bytes);

--- a/Lib/Classes/2D Barcodes/Decoder/ZXing.QrCode.Internal.QRCodeDecoderMetaData.pas
+++ b/Lib/Classes/2D Barcodes/Decoder/ZXing.QrCode.Internal.QRCodeDecoderMetaData.pas
@@ -43,7 +43,7 @@ type
     /// Apply the result points' order correction due to mirroring.
     /// </summary>
     /// <param name="points">Array of points to apply mirror correction to.</param>
-    procedure applyMirroredCorrection(const points: TArray<TResultPoint>);
+    procedure applyMirroredCorrection(const points: TArray<IResultPoint>);
 
     /// <summary>
     /// true if the QR Code was mirrored.
@@ -61,9 +61,9 @@ begin
 end;
 
 procedure TQRCodeDecoderMetaData.applyMirroredCorrection(
-  const points: TArray<TResultPoint>);
+  const points: TArray<IResultPoint>);
 var
-  bottomLeft: TResultPoint;
+  bottomLeft: IResultPoint;
 begin
   if ((FMirrored and (points <> nil)) and (Length(points) >= 3)) then
   begin

--- a/Lib/Classes/2D Barcodes/Detector/ZXing.QrCode.Internal.AlignmentPattern.pas
+++ b/Lib/Classes/2D Barcodes/Detector/ZXing.QrCode.Internal.AlignmentPattern.pas
@@ -19,23 +19,17 @@
 }
 
 unit ZXing.QrCode.Internal.AlignmentPattern;
-
 interface
-
-uses 
-  ZXing.ResultPoint;
+uses ZXing.ResultPoint;
 
 type
-  /// <summary> <p>Encapsulates an alignment pattern, which are the smaller square patterns found in
-  /// all but the simplest QR Codes.</p>
-  ///
+  /// <summary>
+  ///  As we did for ResultPoint, we use an interfaced object to implement automatic deallocation
+  /// of TAligmnentPattern instances
+  /// the actual implementation of this interface is in unit ZXing.QrCode.Internal.AlignmentPatternImplementation
   /// </summary>
-  TAlignmentPattern = class sealed(TResultPoint)
-  private
-    estimatedModuleSize: Single;
-  public
-    constructor Create(const posX, posY, estimatedModuleSize: Single);
-
+  IAlignmentPattern = interface(IResultPoint)
+     ['{8C0A5D01-9620-42B6-BE3E-9C40717B5B38}']
     /// <summary> <p>Determines if this alignment pattern "about equals" an alignment pattern at the stated
     /// position and size -- meaning, it is at nearly the same center with nearly the same size.</p>
     /// </summary>
@@ -49,53 +43,27 @@ type
     /// <param name="j">The j.</param>
     /// <param name="newModuleSize">New size of the module.</param>
     /// <returns></returns>
-    function combineEstimate(const i, j,
-      newModuleSize: Single): TAlignmentPattern;
-    constructor Clone(const src: TAlignmentPattern);
+    function combineEstimate(const i, j, newModuleSize: Single): IAlignmentPattern;
+  end;
+
+
+  /// <summary>
+  ///  contains all static methods for using IAlignmentPatterns instances
+  /// </summary>
+  TAlignmentPatternHelpers = class
+    /// <summary>
+    ///  IAlignmentPattern instances must be obtained by calling this function
+    /// </summary>
+    class function CreateAlignmentPattern(const posX, posY, estimatedModuleSize: Single):IAlignmentPattern;
   end;
 
 implementation
+uses ZXing.QrCode.Internal.AlignmentPatternImplementation;
 
-{ TAlignmentPattern }
-
-constructor TAlignmentPattern.Create(const posX, posY,
-  estimatedModuleSize: Single);
+{ TAlignmentPatternHelpers }
+class function TAlignmentPatternHelpers.CreateAlignmentPattern(const posX, posY, estimatedModuleSize: Single):IAlignmentPattern;
 begin
-  inherited Create(posX, posY);
-
-  Self.estimatedModuleSize := estimatedModuleSize;
-end;
-
-function TAlignmentPattern.aboutEquals(const moduleSize, i, j: Single): Boolean;
-var
-  moduleSizeDiff: Single;
-begin
-  if ((Abs(i - Self.y) <= moduleSize) and
-      (Abs(j - Self.x) <= moduleSize)) then
-  begin
-    moduleSizeDiff := Abs(moduleSize - self.estimatedModuleSize);
-    Result := ((moduleSizeDiff <= 1) or
-               (moduleSizeDiff <= self.estimatedModuleSize));
-  end else Result := false;
-end;
-
-function TAlignmentPattern.combineEstimate(const i, j,
-  newModuleSize: Single): TAlignmentPattern;
-var
-  combinedX,
-  combinedY,
-  combinedModuleSize : Single;
-begin
-  combinedX := (self.x + j) / 2.0;
-  combinedY := (self.y + i) / 2.0;
-  combinedModuleSize := (estimatedModuleSize + newModuleSize) / 2.0;
-  Result := TAlignmentPattern.Create(combinedX, combinedY, combinedModuleSize);
-end;
-
-constructor TAlignmentPattern.Clone(const src: TAlignmentPattern);
- begin
-  inherited Clone(src);
-  self.estimatedModuleSize  := src.estimatedModuleSize;
+    result := ZXing.QrCode.Internal.AlignmentPatternImplementation.NewAlignmentPattern(posX,posY,estimatedModuleSize);
 end;
 
 end.

--- a/Lib/Classes/2D Barcodes/Detector/ZXing.QrCode.Internal.AlignmentPatternFinder.pas
+++ b/Lib/Classes/2D Barcodes/Detector/ZXing.QrCode.Internal.AlignmentPatternFinder.pas
@@ -47,7 +47,7 @@ type
   TAlignmentPatternFinder = class sealed
   private
     image: TBitMatrix;
-    possibleCenters: TList<TAlignmentPattern>;
+    possibleCenters: TList<IAlignmentPattern>;
     startX, startY: Integer;
     width, height: Integer;
     moduleSize: Single;
@@ -98,7 +98,7 @@ type
     /// <returns> {@link TAlignmentPattern} if we have found the same pattern twice, or null if not
     /// </returns>
     function handlePossibleCenter(const stateCount: TArray<Integer>;
-      const i, j: Integer): TAlignmentPattern;
+      const i, j: Integer): IAlignmentPattern;
   public
     /// <summary> <p>Creates a finder that will look in a portion of the whole image.</p>
     ///
@@ -126,7 +126,7 @@ type
     /// </summary>
     /// <returns> {@link TAlignmentPattern} if found
     /// </returns>
-    function find: TAlignmentPattern;
+    function find: IAlignmentPattern;
   end;
 
 implementation
@@ -138,7 +138,7 @@ constructor TAlignmentPatternFinder.Create(const image: TBitMatrix;
   resultPointCallback: TResultPointCallback);
 begin
   Self.image := image;
-  Self.possibleCenters := TList<TAlignmentPattern>.Create;
+  Self.possibleCenters := TList<IAlignmentPattern>.Create;
   Self.possibleCenters.Capacity := 5;
   Self.startX := startX;
   Self.startY := startY;
@@ -150,22 +150,18 @@ begin
 end;
 
 destructor TAlignmentPatternFinder.Destroy;
-var
-  alignmentPattern : TAlignmentPattern;
 begin
-  for alignmentPattern in possibleCenters do
-    alignmentPattern.Free;
-
-  self.possibleCenters.Clear;
+  if possibleCenters<>nil then
+     possibleCenters.Clear;
   FreeAndNil(self.possibleCenters);
   self.crossCheckStateCount := nil;
   self.resultPointCallback :=nil;
   inherited;
 end;
 
-function TAlignmentPatternFinder.find: TAlignmentPattern;
+function TAlignmentPatternFinder.find: IAlignmentPattern;
 var
-  confirmed: TAlignmentPattern;
+  confirmed: IAlignmentPattern;
   maxJ, middleI, iGen, i, j, currentState: Integer;
   stateCount: TArray<Integer>;
 begin
@@ -370,9 +366,9 @@ begin
 end;
 
 function TAlignmentPatternFinder.handlePossibleCenter(
-  const stateCount: TArray<Integer>; const i, j: Integer): TAlignmentPattern;
+  const stateCount: TArray<Integer>; const i, j: Integer): IAlignmentPattern;
 var
-  center, point: TAlignmentPattern;
+  center, point: IAlignmentPattern;
   stateCountTotal: Integer;
   estimatedModuleSize: Single;
   centerJ, centerI: Single;
@@ -399,7 +395,7 @@ begin
       end;
     end;
     // Hadn't found this before; save it
-    point := TAlignmentPattern.Create(centerJ, centerI, estimatedModuleSize);
+    point := TAlignmentPatternHelpers.CreateAlignmentPattern(centerJ, centerI, estimatedModuleSize);
     Self.possibleCenters.Add(point);
     if Assigned(resultPointCallback)
     then

--- a/Lib/Classes/2D Barcodes/Detector/ZXing.QrCode.Internal.AlignmentPatternImplementation.pas
+++ b/Lib/Classes/2D Barcodes/Detector/ZXing.QrCode.Internal.AlignmentPatternImplementation.pas
@@ -1,0 +1,112 @@
+{
+  * Copyright 2007 ZXing authors
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+
+  * Original Author: Sean Owen
+  * Ported from ZXING Java Source: www.Redivivus.in (suraj.supekar@redivivus.in)
+  * Delphi Implementation by E.Spelt and K. Gossens
+}
+
+unit ZXing.QrCode.Internal.AlignmentPatternImplementation;
+
+
+interface
+
+uses
+  ZXing.QrCode.Internal.AlignmentPattern,
+  ZXing.ResultPoint,
+  ZXing.ResultPointImplementation;
+
+// this is the function that actually creates IAlignmentPattern instances.
+// the actual implementation of the interface is totally hidden to all other units,
+// since even its declaration is in the implementation section of this unit
+function NewAlignmentPattern(const posX, posY, estimatedModuleSize: Single):IAlignmentPattern;
+
+
+implementation
+
+{ TAlignmentPattern }
+
+
+type
+  /// <summary> <p>Encapsulates an alignment pattern, which are the smaller square patterns found in
+  /// all but the simplest QR Codes.</p>
+  ///
+  /// </summary>
+  TAlignmentPattern = class sealed(TResultPoint,IResultPoint,IAlignmentPattern)
+  private
+    estimatedModuleSize: Single;
+    constructor Create(const posX, posY, estimatedModuleSize: Single);
+
+    /// <summary> <p>Determines if this alignment pattern "about equals" an alignment pattern at the stated
+    /// position and size -- meaning, it is at nearly the same center with nearly the same size.</p>
+    /// </summary>
+    function aboutEquals(const moduleSize, i, j: Single): Boolean;
+
+    /// <summary>
+    /// Combines this object's current estimate of a finder pattern position and module size
+    /// with a new estimate. It returns a new {@code FinderPattern} containing an average of the two.
+    /// </summary>
+    /// <param name="i">The i.</param>
+    /// <param name="j">The j.</param>
+    /// <param name="newModuleSize">New size of the module.</param>
+    /// <returns></returns>
+    function combineEstimate(const i, j,
+      newModuleSize: Single): IAlignmentPattern;
+  end;
+
+
+constructor TAlignmentPattern.Create(const posX, posY,
+  estimatedModuleSize: Single);
+begin
+  inherited Create(posX, posY);
+
+  Self.estimatedModuleSize := estimatedModuleSize;
+end;
+
+function TAlignmentPattern.aboutEquals(const moduleSize, i, j: Single): Boolean;
+var
+  moduleSizeDiff: Single;
+begin
+  if ((Abs(i - Self.y) <= moduleSize) and
+      (Abs(j - Self.x) <= moduleSize)) then
+  begin
+    moduleSizeDiff := Abs(moduleSize - self.estimatedModuleSize);
+    Result := ((moduleSizeDiff <= 1) or
+               (moduleSizeDiff <= self.estimatedModuleSize));
+  end else Result := false;
+end;
+
+function TAlignmentPattern.combineEstimate(const i, j,
+  newModuleSize: Single): IAlignmentPattern;
+var
+  combinedX,
+  combinedY,
+  combinedModuleSize : Single;
+begin
+  combinedX := (self.x + j) / 2.0;
+  combinedY := (self.y + i) / 2.0;
+  combinedModuleSize := (estimatedModuleSize + newModuleSize) / 2.0;
+  Result := TAlignmentPattern.Create(combinedX, combinedY, combinedModuleSize);
+end;
+
+
+
+
+function NewAlignmentPattern(const posX, posY, estimatedModuleSize: Single):IAlignmentPattern;
+begin
+   result := TAlignmentPattern.Create(posX,posY,estimatedModuleSize);
+end;
+
+end.

--- a/Lib/Classes/2D Barcodes/Detector/ZXing.QrCode.Internal.Detector.pas
+++ b/Lib/Classes/2D Barcodes/Detector/ZXing.QrCode.Internal.Detector.pas
@@ -49,15 +49,15 @@ type
     FImage: TBitMatrix;
     FResultPointCallback: TResultPointCallback;
 
-    function calculateModuleSizeOneWay(pattern: TResultpoint;
-      otherPattern: TResultpoint): Single;
+    function calculateModuleSizeOneWay(pattern: IResultpoint;
+      otherPattern: IResultpoint): Single;
 
-    class function computeDimension(topLeft: TResultpoint;
-      topRight: TResultpoint; bottomLeft: TResultpoint; moduleSize: Single;
+    class function computeDimension(topLeft: IResultpoint;
+      topRight: IResultpoint; bottomLeft: IResultpoint; moduleSize: Single;
       var dimension: Integer): boolean; static;
 
     class function createTransform(const topLeft, topRight, bottomLeft,
-      AlignmentPattern: TResultpoint; const dimension: Integer)
+      AlignmentPattern: IResultpoint; const dimension: Integer)
       : TPerspectiveTransform; static;
 
     class function sampleGrid(image: TBitMatrix;
@@ -68,11 +68,11 @@ type
       toX: Integer; toY: Integer): Single;
   protected
     function calculateModuleSize(const topLeft, topRight,
-      bottomLeft: TResultpoint): Single; virtual;
+      bottomLeft: IResultPoint): Single; virtual;
 
     function findAlignmentInRegion(const overallEstModuleSize: Single;
       const estAlignmentX, estAlignmentY: Integer;
-      const allowanceFactor: Single): TAlignmentPattern;
+      const allowanceFactor: Single): IAlignmentPattern;
 
     /// <summary>
     /// Processes the finder pattern info.
@@ -128,14 +128,14 @@ begin
 end;
 
 function TDetector.calculateModuleSize(const topLeft, topRight,
-  bottomLeft: TResultpoint): Single;
+  bottomLeft: IResultPoint): Single;
 begin
   Result := ((self.calculateModuleSizeOneWay(topLeft, topRight) +
     self.calculateModuleSizeOneWay(topLeft, bottomLeft)) / 2)
 end;
 
-function TDetector.calculateModuleSizeOneWay(pattern: TResultpoint;
-  otherPattern: TResultpoint): Single;
+function TDetector.calculateModuleSizeOneWay(pattern: IResultPoint;
+  otherPattern: IResultPoint): Single;
 var
   moduleSizeEst1, moduleSizeEst2: Single;
 
@@ -160,17 +160,17 @@ begin
   Result := ((moduleSizeEst1 + moduleSizeEst2) / 14);
 end;
 
-class function TDetector.computeDimension(topLeft: TResultpoint;
-  topRight: TResultpoint; bottomLeft: TResultpoint; moduleSize: Single;
+class function TDetector.computeDimension(topLeft: IResultPoint;
+  topRight: IResultPoint; bottomLeft: IResultPoint; moduleSize: Single;
   var dimension: Integer): boolean;
 
 var
   tltrCentersDimension, tlblCentersDimension: Integer;
 begin
   tltrCentersDimension :=
-    round((TResultpoint.distance(topLeft, topRight) / moduleSize));
+    round((TResultPointHelpers.distance(topLeft, topRight) / moduleSize));
   tlblCentersDimension :=
-    round((TResultpoint.distance(topLeft, bottomLeft) / moduleSize));
+    round((TResultPointHelpers.distance(topLeft, bottomLeft) / moduleSize));
   dimension := TMathUtils.Asr
     ((tltrCentersDimension + tlblCentersDimension), 1) + 7;
 
@@ -196,7 +196,7 @@ begin
 end;
 
 class function TDetector.createTransform(const topLeft, topRight, bottomLeft,
-  AlignmentPattern: TResultpoint; const dimension: Integer)
+  AlignmentPattern: IResultPoint; const dimension: Integer)
   : TPerspectiveTransform;
 var
   bottomRightX, bottomRightY, sourceBottomRightX, sourceBottomRightY,
@@ -264,14 +264,14 @@ end;
 function TDetector.processFinderPatternInfo(const info: TFinderPatternInfo)
   : TDetectorResult;
 var
-  topLeft, topRight, bottomLeft: TFinderPattern;
+  topLeft, topRight, bottomLeft: IFinderPattern;
   moduleSize, bottomRightX, bottomRightY, correctionToTopLeft: Single;
   dimension, i, modulesBetweenFPCenters, estAlignmentX, estAlignmentY: Integer;
-  points: TArray<TResultpoint>;
+  points: TArray<IResultPoint>;
   provisionalVersion: TVersion;
   transform: TPerspectiveTransform;
   bits: TBitMatrix;
-  AlignmentPattern: TAlignmentPattern;
+  AlignmentPattern: IAlignmentPattern;
 begin
   Result := nil;
 
@@ -332,9 +332,9 @@ begin
     exit;
 
   if (AlignmentPattern = nil) then
-    points := TArray<TResultpoint>.Create(bottomLeft, topLeft, topRight)
+    points := TArray<IResultPoint>.Create(bottomLeft, topLeft, topRight)
   else
-    points := TArray<TResultpoint>.Create(bottomLeft, topLeft, topRight,
+    points := TArray<IResultPoint>.Create(bottomLeft, topLeft, topRight,
       AlignmentPattern);
 
   Result := TDetectorResult.Create(bits, points);
@@ -342,12 +342,12 @@ end;
 
 function TDetector.findAlignmentInRegion(const overallEstModuleSize: Single;
   const estAlignmentX, estAlignmentY: Integer; const allowanceFactor: Single)
-  : TAlignmentPattern;
+  : IAlignmentPattern;
 var
   allowance, alignmentAreaRightX, alignmentAreaLeftX, alignmentAreaTopY,
     alignmentAreaBottomY: Integer;
   alignmentFinder: TAlignmentPatternFinder;
-  candidateResult: TAlignmentPattern;
+  candidateResult: IAlignmentPattern;
 begin
   Result := nil;
 
@@ -375,7 +375,7 @@ begin
   if candidateResult = nil then
     Result := nil
   else
-    Result := TAlignmentPattern.Clone(candidateResult);
+    Result := candidateResult;
 
   FreeAndNil(alignmentFinder);
 end;

--- a/Lib/Classes/2D Barcodes/Detector/ZXing.QrCode.Internal.FinderPatternImplementation.pas
+++ b/Lib/Classes/2D Barcodes/Detector/ZXing.QrCode.Internal.FinderPatternImplementation.pas
@@ -1,0 +1,159 @@
+{
+  * Copyright 2007 ZXing authors
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+
+  * Original Author: Sean Owen
+  * Delphi Implementation by E. Spelt and K. Gossens
+}
+
+unit ZXing.QrCode.Internal.FinderPatternImplementation;
+
+interface
+uses
+  ZXing.QrCode.Internal.FinderPattern;
+
+
+function NewFinderPattern(const posX, posY, estimatedModuleSize: Single; const count: Integer):IFinderPattern; overload;
+function NewFinderPattern(const posX, posY, estimatedModuleSize: Single):IFinderPattern; overload;
+
+
+implementation
+uses ZXing.ResultPoint,ZXing.ResultPointImplementation;
+
+{ TFinderPattern }
+
+
+type
+  /// <summary>
+  /// <p>Encapsulates a finder pattern, which are the three square patterns found in
+  /// the corners of QR Codes. It also encapsulates a count of similar finder patterns,
+  /// as a convenience to the finder's bookkeeping.</p>
+  /// </summary>
+  TFinderPattern = class(TResultPoint,IResultPoint,IFinderPattern)
+  private
+    Fcount: Integer;
+    FestimatedModuleSize: Single;
+
+    function GetCount:integer;
+    procedure SetCount(value:integer);
+
+    constructor Create(const posX, posY, estimatedModuleSize: Single;
+      const count: Integer); overload;
+    constructor Create(const posX, posY, estimatedModuleSize: Single); overload;
+
+    /// <summary> <p>Determines if this finder pattern "about equals" a finder pattern at the stated
+    /// position and size -- meaning, it is at nearly the same center with nearly the same size.</p>
+    /// </summary>
+    function aboutEquals(const moduleSize, i, j: Single): Boolean;
+
+    /// <summary>
+    /// Combines this object's current estimate of a finder pattern position and module size
+    /// with a new estimate. It returns a new {@code FinderPattern} containing a weighted average
+    /// based on count.
+    /// </summary>
+    /// <param name="i">The i.</param>
+    /// <param name="j">The j.</param>
+    /// <param name="newModuleSize">New size of the module.</param>
+    /// <returns></returns>
+    function combineEstimate(const i, j, newModuleSize: Single): IFinderPattern;
+
+    /// <summary>
+    /// Gets the size of the estimated module.
+    /// </summary>
+    /// <value>
+    /// The size of the estimated module.
+    /// </value>
+    function estimatedModuleSize : Single;
+    property count : Integer read GetCount write SetCount;
+  end;
+
+
+constructor TFinderPattern.Create(const posX, posY,
+  estimatedModuleSize: Single; const count: Integer);
+begin
+  inherited Create(posX, posY);
+
+  FestimatedModuleSize := estimatedModuleSize;
+  Fcount := count;
+end;
+
+constructor TFinderPattern.Create(const posX, posY,
+  estimatedModuleSize: Single);
+begin
+  Self.Create(posX, posY, estimatedModuleSize, 1);
+end;
+
+function TFinderPattern.estimatedModuleSize: Single;
+begin
+  result := FestimatedModuleSize;
+end;
+
+function TFinderPattern.GetCount: integer;
+begin
+   result := FCount;
+end;
+
+function TFinderPattern.aboutEquals(const moduleSize, i, j: Single): Boolean;
+var
+  moduleSizeDiff,
+  x, y: Single;
+begin
+  Result := false;
+
+  x := Self.x;
+  y := Self.y;
+
+  if ((Abs(i - self.y) <= moduleSize) and (Abs(j - self.x) <= moduleSize)) then
+  begin
+    moduleSizeDiff := Abs(moduleSize - self.estimatedModuleSize);
+
+    Result := ((moduleSizeDiff <= 1) or
+      (moduleSizeDiff <= self.estimatedModuleSize));
+  end;
+end;
+
+
+
+procedure TFinderPattern.SetCount(value: integer);
+begin
+   FCount := value;
+end;
+
+function TFinderPattern.combineEstimate(const i, j,
+  newModuleSize: Single): IFinderPattern;
+var
+  combinedCount: Integer;
+  combinedX, combinedY: Single;
+begin
+  combinedCount := (Self.count + 1);
+  combinedX := ((Self.count * Self.x) + j) / combinedCount;
+  combinedY := ((Self.count * Self.y) + i) / combinedCount;
+  Result := TFinderPattern.Create(combinedX, combinedY,
+    (((Self.count * Self.estimatedModuleSize) + newModuleSize) / combinedCount),
+    combinedCount)
+end;
+
+
+function NewFinderPattern(const posX, posY, estimatedModuleSize: Single; const count: Integer):IFinderPattern;
+begin
+   result := TFinderPattern.Create( posX, posY, estimatedModuleSize,count);
+end;
+
+function NewFinderPattern(const posX, posY, estimatedModuleSize: Single):IFinderPattern;
+begin
+   result := TFinderPattern.Create( posX, posY, estimatedModuleSize);
+end;
+
+
+end.

--- a/Lib/Classes/2D Barcodes/Detector/ZXing.QrCode.Internal.FinderPatternInfo.pas
+++ b/Lib/Classes/2D Barcodes/Detector/ZXing.QrCode.Internal.FinderPatternInfo.pas
@@ -31,35 +31,35 @@ type
   /// </summary>
   TFinderPatternInfo = class sealed
   private
-    FbottomLeft: TFinderPattern;
-    FtopLeft: TFinderPattern;
-    FtopRight: TFinderPattern;
+    FbottomLeft: IFinderPattern;
+    FtopLeft: IFinderPattern;
+    FtopRight: IFinderPattern;
   public
     /// <summary>
     /// Initializes a new instance of the <see cref="FinderPatternInfo"/> class.
     /// </summary>
     /// <param name="patternCenters">The pattern centers.</param>
-    constructor Create(const patternCenters: TArray<TFinderPattern>);
+    constructor Create(const patternCenters: TArray<IFinderPattern>);
 
     /// <summary>
     /// Gets the bottom left.
     /// </summary>
-    property bottomLeft : TFinderPattern read FbottomLeft;
+    property bottomLeft : IFinderPattern read FbottomLeft;
 
     /// <summary>
     /// Gets the top left.
     /// </summary>
-    property topLeft : TFinderPattern read FtopLeft;
+    property topLeft : IFinderPattern read FtopLeft;
 
     /// <summary>
     /// Gets the top right.
     /// </summary>
-    property topRight : TFinderPattern read FtopRight;
+    property topRight : IFinderPattern read FtopRight;
   end;
 
 implementation
 
-constructor TFinderPatternInfo.Create(const patternCenters: TArray<TFinderPattern>);
+constructor TFinderPatternInfo.Create(const patternCenters: TArray<IFinderPattern>);
 begin
   FbottomLeft := patternCenters[0];
   FtopLeft := patternCenters[1];

--- a/Lib/Classes/2D Barcodes/ZXing.Datamatrix.DataMatrixReader.pas
+++ b/Lib/Classes/2D Barcodes/ZXing.Datamatrix.DataMatrixReader.pas
@@ -47,7 +47,7 @@ type
   TDataMatrixReader = class(TInterfacedObject, IReader)
   private
     FDecoder: TDataMatrixDecoder;
-    NO_POINTS: TArray<TResultPoint>;
+    NO_POINTS: TArray<IResultPoint>;
 
     /// <summary>
     /// This method detects a code in a "pure" image -- that is, pure monochrome image
@@ -84,7 +84,7 @@ constructor TDataMatrixReader.Create;
 begin
   inherited;
   FDecoder := TDataMatrixDecoder.Create;
-  NO_POINTS := TArray<TResultPoint>.Create();
+  NO_POINTS := TArray<IResultPoint>.Create();
 end;
 
 destructor TDataMatrixReader.Destroy;
@@ -104,7 +104,7 @@ function TDataMatrixReader.decode(const image: TBinaryBitmap;
 var
   matrixDetector: TDataMatrixDetector;
   DecoderResult: TDecoderResult;
-  points: TArray<TResultPoint>;
+  points: TArray<IResultPoint>;
   bits: TBitMatrix;
   DetectorResult: TDetectorResult;
   byteSegments: TList<TArray<Byte>>;

--- a/Lib/Classes/2D Barcodes/ZXing.QrCode.QRCodeReader.pas
+++ b/Lib/Classes/2D Barcodes/ZXing.QrCode.QRCodeReader.pas
@@ -48,7 +48,7 @@ type
   TQRCodeReader = class(TInterfacedObject, IReader)
   private
     FDecoder: TQRDecoder;
-    NO_POINTS: TArray<TResultPoint>;
+    NO_POINTS: TArray<IResultPoint>;
 
     /// <summary>
     /// This method detects a code in a "pure" image -- that is, pure monochrome image
@@ -107,7 +107,7 @@ constructor TQRCodeReader.Create;
 begin
   inherited;
   FDecoder := TQRDecoder.Create;
-  NO_POINTS := TArray<TResultPoint>.Create();
+  NO_POINTS := TArray<IResultPoint>.Create();
 end;
 
 destructor TQRCodeReader.Destroy;
@@ -127,7 +127,7 @@ function TQRCodeReader.decode(const image: TBinaryBitmap;
 var
   DecoderResult: TDecoderResult;
   Detector: TDetector;
-  points: TArray<TResultPoint>;
+  points: TArray<IResultPoint>;
   bits: TBitMatrix;
   DetectorResult: TDetectorResult;
   data: TQRCodeDecoderMetaData;

--- a/Lib/Classes/Common/Detector/ZXing.Common.Detector.WhiteRectangleDetector.pas
+++ b/Lib/Classes/Common/Detector/ZXing.Common.Detector.WhiteRectangleDetector.pas
@@ -44,17 +44,17 @@ type
     constructor Create(image: TBitMatrix); overload;
     constructor Create(image: TBitMatrix; initSize: Integer; x: Integer;
       y: Integer); overload;
-    function centerEdges(y: TResultPoint; z: TResultPoint; x: TResultPoint;
-      t: TResultPoint): TArray<TResultPoint>;
+    function centerEdges(y: IResultPoint; z: IResultPoint; x: IResultPoint;
+      t: IResultPoint): TArray<IResultPoint>;
     function containsBlackPoint(a: Integer; b: Integer; fixed: Integer;
       horizontal: boolean): boolean;
     function getBlackPointOnSegment(aX: Single; aY: Single; bX: Single;
-      bY: Single): TResultPoint;
+      bY: Single): IResultPoint;
   public
     class function New(image: TBitMatrix): TWhiteRectangleDetector; overload;
     class function New(image: TBitMatrix; initSize: Integer; x: Integer;
       y: Integer): TWhiteRectangleDetector; overload; static;
-    function detect(): TArray<TResultPoint>;
+    function detect(): TArray<IResultPoint>;
   end;
 
 implementation
@@ -81,8 +81,8 @@ begin
   Self.downInit := (y + halfsize);
 end;
 
-function TWhiteRectangleDetector.centerEdges(y: TResultPoint; z: TResultPoint;
-  x: TResultPoint; t: TResultPoint): TArray<TResultPoint>;
+function TWhiteRectangleDetector.centerEdges(y: IResultPoint; z: IResultPoint;
+  x: IResultPoint; t: IResultPoint): TArray<IResultPoint>;
 var
   yi, yj, zi, zj, xi, xj, ti, tj: Single;
 begin
@@ -97,15 +97,15 @@ begin
 
   if (yi < (Self.width div 2)) then
   begin
-    Result := TArray<TResultPoint>.Create(TResultPoint.Create((ti - 1), (tj + 1)
-      ), TResultPoint.Create((zi + 1), (zj + 1)), TResultPoint.Create((xi - 1),
-      (xj - 1)), TResultPoint.Create((yi + 1), (yj - 1)));
+    Result := TArray<IResultPoint>.Create(TResultPointHelpers.CreateResultPoint((ti - 1), (tj + 1)
+      ), TResultPointHelpers.CreateResultPoint((zi + 1), (zj + 1)), TResultPointHelpers.CreateResultPoint((xi - 1),
+      (xj - 1)), TResultPointHelpers.CreateResultPoint((yi + 1), (yj - 1)));
     exit;
   end;
 
-  Result := TArray<TResultPoint>.Create(TResultPoint.Create((ti + 1), (tj + 1)),
-    TResultPoint.Create((zi + 1), (zj - 1)), TResultPoint.Create((xi - 1),
-    (xj + 1)), TResultPoint.Create((yi - 1), (yj - 1)));
+  Result := TArray<IResultPoint>.Create(TResultPointHelpers.CreateResultPoint((ti + 1), (tj + 1)),
+    TResultPointHelpers.CreateResultPoint((zi + 1), (zj - 1)), TResultPointHelpers.CreateResultPoint((xi - 1),
+    (xj + 1)), TResultPointHelpers.CreateResultPoint((yi - 1), (yj - 1)));
 
 end;
 
@@ -183,7 +183,7 @@ begin
   end;
 end;
 
-function TWhiteRectangleDetector.detect: TArray<TResultPoint>;
+function TWhiteRectangleDetector.detect: TArray<IResultPoint>;
 var
   left, right, up, down: Integer;
   sizeExceeded, aBlackPointFoundOnBorder, atLeastOneBlackPointFoundOnBorder,
@@ -192,7 +192,7 @@ var
   rightBorderNotWhite, bottomBorderNotWhite, leftBorderNotWhite,
   topBorderNotWhite: boolean;
   i: Integer;
-  z, t, x, y: TResultPoint;
+  z, t, x, y: IResultPoint;
   maxSize: Integer;
 begin
   z := nil;
@@ -308,83 +308,73 @@ begin
     exit;
   end;
 
-  try
-
-    maxSize := (right - left);
-    i := 1;
-    while ((i < maxSize)) do
-    begin
-      z := Self.getBlackPointOnSegment(left, (down - i), (left + i), down);
-      if (z <> nil) then
-        break;
-      Inc(i);
-    end;
-
-    if (z = nil) then
-    begin
-      Result := nil;
-      exit;
-    end;
-
-    i := 1;
-    while ((i < maxSize)) do
-    begin
-      t := Self.getBlackPointOnSegment(left, (up + i), (left + i), up);
-      if (t <> nil) then
-        break;
-      Inc(i);
-    end;
-
-    if (t = nil) then
-    begin
-      Result := nil;
-      exit;
-    end;
-
-    i := 1;
-    while ((i < maxSize)) do
-    begin
-      x := Self.getBlackPointOnSegment(right, (up + i), (right - i), up);
-      if (x <> nil) then
-        break;
-      Inc(i);
-    end;
-
-    if (x = nil) then
-    begin
-      Result := nil;
-      exit;
-    end;
-
-    y := nil;
-    i := 1;
-    while ((i < maxSize)) do
-    begin
-      y := Self.getBlackPointOnSegment(right, (down - i), (right - i), down);
-      if (y <> nil) then
-        break;
-      Inc(i);
-    end;
-
-    if (y = nil) then
-    begin
-      Result := nil;
-      exit;
-    end;
-
-    Result := Self.centerEdges(y, z, x, t);
-
-  finally
-    y.Free;
-    z.Free;
-    x.Free;
-    t.Free;
+  maxSize := (right - left);
+  i := 1;
+  while ((i < maxSize)) do
+  begin
+    z := Self.getBlackPointOnSegment(left, (down - i), (left + i), down);
+    if (z <> nil) then
+      break;
+    Inc(i);
   end;
 
+  if (z = nil) then
+  begin
+    Result := nil;
+    exit;
+  end;
+
+  i := 1;
+  while ((i < maxSize)) do
+  begin
+    t := Self.getBlackPointOnSegment(left, (up + i), (left + i), up);
+    if (t <> nil) then
+      break;
+    Inc(i);
+  end;
+
+  if (t = nil) then
+  begin
+    Result := nil;
+    exit;
+  end;
+
+  i := 1;
+  while ((i < maxSize)) do
+  begin
+    x := Self.getBlackPointOnSegment(right, (up + i), (right - i), up);
+    if (x <> nil) then
+      break;
+    Inc(i);
+  end;
+
+  if (x = nil) then
+  begin
+    Result := nil;
+    exit;
+  end;
+
+  y := nil;
+  i := 1;
+  while ((i < maxSize)) do
+  begin
+    y := Self.getBlackPointOnSegment(right, (down - i), (right - i), down);
+    if (y <> nil) then
+      break;
+    Inc(i);
+  end;
+
+  if (y = nil) then
+  begin
+    Result := nil;
+    exit;
+  end;
+
+  Result := Self.centerEdges(y, z, x, t);
 end;
 
 function TWhiteRectangleDetector.getBlackPointOnSegment(aX: Single; aY: Single;
-  bX: Single; bY: Single): TResultPoint;
+  bX: Single; bY: Single): IResultPoint;
 var
   i, x, y, dist: Integer;
   xStep, yStep: Single;
@@ -399,7 +389,7 @@ begin
     y := TMathUtils.round((aY + (i * yStep)));
     if (Self.image[x, y]) then
     begin
-      Result := TResultPoint.Create(x, y);
+      Result := TResultPointHelpers.CreateResultPoint(x, y);
       exit;
     end;
     Inc(i);

--- a/Lib/Classes/Common/ZXing.Common.BitArray.pas
+++ b/Lib/Classes/Common/ZXing.Common.BitArray.pas
@@ -21,446 +21,50 @@ unit ZXing.Common.BitArray;
 
 interface
 
-uses
-  System.SysUtils,
-  ZXing.Common.Detector.MathUtils;
-
 type
-  /// <summary>
-  /// A simple, fast array of bits, represented compactly by an array of ints internally.
-  /// </summary>
-  TBitArray = class
-  private
-    _lookup: TArray<Integer>;
-    Fbits: TArray<Integer>;
-    Fsize: Integer;
-    procedure InitLookup();
-    function GetBit(i: Integer): Boolean;
-    procedure SetBit(i: Integer; Value: Boolean);
-    function makeArray(Size: Integer): TArray<Integer>;
-    procedure BitArray(bits: TArray<Integer>; size: Integer);
-    procedure ensureCapacity(size: Integer);
+  IBitArray = interface
+    ['{3D65F451-E408-4015-A637-73CD05877BCB}']
+     // property getters and setters
+     function GetBit(i: Integer): Boolean;
+     procedure SetBit(i: Integer; Value: Boolean);
+     function GetBits: TArray<Integer>;
 
-	
-    function numberOfTrailingZeros(num: Integer): Integer;
-  public
-    property Size: Integer read Fsize;
-    function SizeInBytes: Integer;
+     function Size: Integer;
+     function SizeInBytes: Integer;
 
-    property Self[i: Integer]: Boolean read GetBit write SetBit; default;
-    property Bits: TArray<Integer> read Fbits;
+     property Self[i: Integer]: Boolean read GetBit write SetBit; default;
+     property Bits: TArray<Integer> read GetBits;
 
-    constructor Create(); overload;
-    constructor Create(const Size: Integer); overload;
-    destructor Destroy; override;
-    function getNextSet(from: Integer): Integer;
-    function getNextUnset(from: Integer): Integer;
+     function getNextSet(from: Integer): Integer;
+     function getNextUnset(from: Integer): Integer;
 
-    procedure setBulk(i, newBits: Integer);
-	procedure setRange(start, ending: Integer);
-    procedure appendBit(bit: Boolean);
-    procedure Reverse();
-    procedure clear();
-    
-    function isRange(start, ending: Integer;
-      const value: Boolean): Boolean;
+     procedure setBulk(i, newBits: Integer);
+     procedure setRange(start, ending: Integer);
+     procedure appendBit(bit: Boolean);
+     procedure Reverse();
+     procedure clear();
+
+     function isRange(start, ending: Integer; const value: Boolean): Boolean;
   end;
+
+ TBitArrayHelpers = class
+    class function CreateBitArray:IBitArray; overload;
+    class function CreateBitArray(const Size: Integer):IBitArray; overload;
+ end;
 
 implementation
+uses ZXing.Common.BitArrayImplementation;
 
-{ TBitArray }
-
-constructor TBitArray.Create;
+class function TBitArrayHelpers.CreateBitArray:IBitArray;
 begin
-  Fsize := 0;
-  SetLength(Fbits, 1);
-  InitLookup();
+  result := ZXing.Common.BitArrayImplementation.NewBitArray;
 end;
 
-constructor TBitArray.Create(const Size: Integer);
-begin
-  if (Size < 1)
-  then
-     raise EArgumentException.Create('size must be at least 1.');
 
-  Fsize := Size;
-  Fbits := makeArray(Size);
-  InitLookup();
+class function TBitArrayHelpers.CreateBitArray(const Size: Integer):IBitArray;
+begin
+  result := ZXing.Common.BitArrayImplementation.NewBitArray(size);
 end;
 
-// For testing only
-procedure TBitArray.BitArray(bits: TArray<Integer>; size: Integer);
-begin
-  Fbits := bits;
-  Fsize := size;
-end;
-
-procedure TBitArray.ensureCapacity(size: Integer);
-var
-  newBits : TArray<Integer>;
-begin
-  if (size > TMathUtils.Asr(Length(Fbits), 5)) then
-  begin
-    newBits := makeArray(size);
-    Move(Fbits[0], newBits[0], Length(Fbits));
-    Fbits := newBits;
-  end;
-end;
-
-destructor TBitArray.Destroy;
-begin
-  Fbits := nil;
-  _lookup := nil;
-  inherited;
-end;
-
-function TBitArray.GetBit(i: Integer): Boolean;
-begin
-  Result := ((Fbits[TMathUtils.Asr(i, 5)]) and (1 shl (i and $1F))) <> 0;
-end;
-
-/// <summary>
-/// Gets the next set.
-/// </summary>
-/// <param name="from">first bit to check</param>
-/// <returns>index of first bit that is set, starting from the given index, or size if none are set
-/// at or beyond this given index</returns>
-function TBitArray.getNextSet(from: Integer): Integer;
-var
-  bitsOffset, 
-  currentBits : Integer;
-begin
-  if (from >= Fsize) then
-  begin
-    Result := Fsize;
-    exit;
-  end;
-  bitsOffset := TMathUtils.Asr(from, 5);
-  currentBits := Fbits[bitsOffset];
-  // mask off lesser bits first
-  currentBits := currentBits and (not((1 shl (from and $1F)) - 1));
-  while (currentBits = 0) do
-  begin
-    Inc(bitsOffset);
-    if (bitsOffset = Length(Fbits)) then
-    begin
-      Result := Fsize;
-      exit;
-    end;
-    currentBits := Fbits[bitsOffset];
-  end;
-
-  Result := (bitsOffset shl 5) + numberOfTrailingZeros(currentBits);
-
-  if (Result > Fsize) then
-  begin
-    Result := Fsize;
-  end;
-
-end;
-
-/// <summary>
-/// see getNextSet(int)
-/// </summary>
-/// <param name="from">index to start looking for unset bit</param>
-/// <returns>index of next unset bit, or <see cref="Size"/> if none are unset until the end</returns>
-function TBitArray.getNextUnset(from: Integer): Integer;
-var
-  bitsOffset, 
-  currentBits: Integer;
-begin
-  if (from >= Fsize) then
-  begin
-    Result := Fsize;
-    exit;
-  end;
-  bitsOffset := TMathUtils.Asr(from, 5);
-  currentBits := not Fbits[bitsOffset];
-
-  // mask off lesser bits first
-  currentBits := currentBits and (not( (1 shl (from and $1F)) - 1));
-  while (currentBits = 0) do
-  begin
-    Inc(bitsOffset);
-    if (bitsOffset = Length(Fbits)) then
-    begin
-      Result := Size;
-      exit;
-    end;
-    currentBits := not Fbits[bitsOffset];
-  end;
-  Result := (bitsOffset shl 5) + numberOfTrailingZeros(currentBits);
-
-  if (Result > Size) 
-  then
-     Result := Size;
-end;
-
-procedure TBitArray.InitLookup;
-begin
-  _lookup := TArray<Integer>.Create(32, 0, 1, 26, 2, 23, 27, 0, 3, 16, 24, 30,
-    28, 11, 0, 13, 4, 7, 17, 0, 25, 22, 31, 15, 29, 10, 12, 6, 0, 21, 14, 9, 5,
-    20, 8, 19, 18);
-end;
-
-function TBitArray.makeArray(Size: Integer): TArray<Integer>;
-var
-  ar: TArray<Integer>;
-begin
-  SetLength(ar, TMathUtils.Asr((Size + 31), 5));
-  Result := ar;
-end;
-
-function TBitArray.numberOfTrailingZeros(num: Integer): Integer;
-var
-  index: Integer;
-begin
-  index := (-num and num) mod 37;
-  if (index < 0) then
-  begin
-    index := index * -1;
-  end;
-  Result := _lookup[index];
-end;
-
-procedure TBitArray.Reverse;
-var
-  newBits: TArray<Integer>;
-  i, len, oldBitsLen, leftOffset, mask, nextInt, currentInt: Integer;
-  x: Int64;
-begin
-
-  SetLength(newBits, Length(Fbits));
-  // reverse all int's first
-  len := TMathUtils.Asr((Size - 1), 5);
-  oldBitsLen := len + 1;
-  for i := 0 to oldBitsLen - 1 do
-  begin
-    x := Fbits[i];
-    x := (TMathUtils.Asr(x, 1) and $55555555) or ((x and $55555555) shl 1);
-    x := (TMathUtils.Asr(x, 2) and $33333333) or ((x and $33333333) shl 2);
-    x := (TMathUtils.Asr(x, 4) and $0F0F0F0F) or ((x and $0F0F0F0F) shl 4);
-    x := (TMathUtils.Asr(x, 8) and $00FF00FF) or ((x and $00FF00FF) shl 8);
-    x := (TMathUtils.Asr(x, 16) and $0000FFFF) or ((x and $0000FFFF) shl 16);
-    newBits[len - i] := x;
-  end;
-  // now correct the int's if the bit size isn't a multiple of 32
-  if (Size <> oldBitsLen * 32) then
-  begin
-    leftOffset := oldBitsLen * 32 - Size;
-    mask := 1;
-    for i := 0 to 31 - leftOffset - 1 do
-    begin
-      mask := (mask shl 1) or 1;
-    end;
-
-    currentInt := TMathUtils.Asr(newBits[0], leftOffset) and mask;
-    for i := 1 to oldBitsLen - 1 do
-    begin
-      nextInt := newBits[i];
-      currentInt := currentInt or (nextInt shl (32 - leftOffset));
-      newBits[i - 1] := currentInt;
-      currentInt := TMathUtils.Asr(nextInt, leftOffset) and mask;
-    end;
-    newBits[oldBitsLen - 1] := currentInt;
-  end;
-
-  Fbits := newBits;
-end;
-
-procedure TBitArray.SetBit(i: Integer; Value: Boolean);
-var
-  index: Integer;
-begin
-  if (Value) then
-  begin
-    index := TMathUtils.Asr(i, 5);
-    Fbits[index] := Fbits[index] or 1 shl (i and $1F);
-  end;
-end;
-
-function TBitArray.SizeInBytes: Integer;
-begin
-  Result := TMathUtils.Asr(Size + 7, 3);
-end;
-
-/// <summary> Sets a block of 32 bits, starting at bit i.
-/// 
-/// </summary>
-/// <param name="i">first bit to set
-/// </param>
-/// <param name="newBits">the new value of the next 32 bits. Note again that the least-significant bit
-/// corresponds to bit i, the next-least-significant to i+1, and so on.
-/// </param>
-procedure TBitArray.setBulk(i, newBits: Integer);
-var
-  r: Integer;
-begin
-  r := TMathUtils.Asr(i, 5);
-  Fbits[r] := newBits;
-end;
-
-/// <summary>
-/// Sets a range of bits.
-/// </summary>
-/// <param name="start">start of range, inclusive.</param>
-/// <param name="ending">end of range, exclusive</param>
-procedure TBitArray.setRange(start, ending: Integer);
-var 
-  firstInt,
-  lastInt,
-  mask,
-  i, j : Integer;
-  firstBit,
-  lastBit : Integer;
-begin
-  if (ending < start)
-  then
-     raise EArgumentException.Create('Start is greater than end');
-
-  if (ending = start)
-  then
-     exit;
-  Dec(ending); // will be easier to treat this as the last actually set bit -- inclusive
-  firstInt := TMathUtils.Asr(start, 5);
-  lastInt := TMathUtils.Asr(ending, 5);
-  for i := firstInt to lastInt do
-  begin
-    if (i > firstInt)
-    then
-       firstBit := start
-    else
-       firstBit := $1F;
-    if (i < lastInt)
-    then
-       lastBit := 31
-    else
-       lastBit := (ending and $1F);
-
-    if ((firstBit = 0) and (lastBit = 31))
-    then
-       mask := -1
-    else
-    begin
-      mask := 0;
-      for j := firstBit to lastBit do
-      begin
-        mask := (mask or (1 shl j));
-      end;
-    end;
-    bits[i] := (bits[i] or mask);
-  end;
-end;
-
-/// <summary> Clears all bits (sets to false).</summary>
-procedure TBitArray.Clear;
-var
-  max, 
-  i: Integer;
-begin
-  max := Length(Fbits);
-  for i := 0 to Pred(max) do
-  begin
-    Fbits[i] := 0;
-  end;
-end;
-
-/// <summary> Efficient method to check if a range of bits is set, or not set.
-///
-/// </summary>
-/// <param name="start">start of range, inclusive.
-/// </param>
-/// <param name="ending">end of range, exclusive
-/// </param>
-/// <param name="value">if true, checks that bits in range are set, otherwise checks that they are not set
-/// </param>
-/// <returns> true iff all bits are set or not set in range, according to value argument
-/// </returns>
-/// <throws>  EIllegalArgumentException if end is less than or equal to start </throws>
-function TBitArray.isRange(start, ending: Integer;
-  const value: Boolean): Boolean;
-var
-  firstInt, 
-  lastInt, 
-  firstBit, 
-  lastBit, 
-  mask, 
-  i, j, 
-  temp: Integer;
-begin
-  if (ending < start) then
-  begin
-    Result := False; // there is a bug here some how. We just exits with fals
-    //exit;
-    //raise EArgumentException.Create('End is greater then start');
-  end;
-
-  if (ending = start) then
-  begin
-    Result := true; // empty range matches
-    exit;
-  end;
-  Dec(ending); // will be easier to treat this as the last actually set bit -- inclusive
-
-  firstInt := TMathUtils.Asr(start, 5);
-  lastInt := TMathUtils.Asr(ending, 5);
-  for i := firstInt to lastInt do
-  begin
-    if (i > firstInt) 
-  	then
-       firstBit := 0
-    else
-       firstBit := (start and $1F);
-
-    if (i < lastInt)
-	  then
-       lastBit := 31
-    else
-       lastBit := (ending and $1F);
-
-    if ((firstBit = 0) and (lastBit = 31))
-  	then
-       mask := -1
-    else
-    begin
-      mask := 0;
-      for j := firstBit to lastBit do
-        mask := mask or (1 shl j);
-    end;
-
-    // Return false if we're looking for 1s and the masked bits[i] isn't all 1s (that is,
-    // equals the mask, or we're looking for 0s and the masked portion is not all 0s
-    if (Value) 
-	  then
-       temp := mask
-  	else
-	   temp := 0;
-    
-    if ((Fbits[i] and mask) <> (temp)) then
-    begin
-      Result := False;
-      exit;
-    end;
-  end;
-
-  Result := true;
-end;
-
-/// <summary>
-/// Appends the bit.
-/// </summary>
-/// <param name="bit">The bit.</param>
-procedure TBitArray.appendBit(bit: Boolean);
-var
-  i: Integer;
-begin
-  ensureCapacity(Fsize + 1);
-  if (bit) then
-  begin
-    i := TMathUtils.Asr(Fsize, 5);
-    bits[i] := (bits[i] or (Fsize and $1F));
-  end;
-  Dec(Fsize);
-end;
 
 end.

--- a/Lib/Classes/Common/ZXing.Common.BitArrayImplementation.pas
+++ b/Lib/Classes/Common/ZXing.Common.BitArrayImplementation.pas
@@ -1,0 +1,479 @@
+unit ZXing.Common.BitArrayImplementation;
+
+interface
+uses ZXing.Common.BitArray;
+
+function NewBitArray:IBitArray; overload;
+function NewBitArray(const Size: Integer):IBitArray; overload;
+
+implementation
+uses
+  System.SysUtils,
+  ZXing.Common.Detector.MathUtils;
+
+
+type
+  /// <summary>
+  /// A simple, fast array of bits, represented compactly by an array of ints internally.
+  /// </summary>
+  TBitArrayImplementation = class(TInterfacedObject, IBitArray)
+  strict private
+    _lookup: TArray<Integer>;
+    Fbits: TArray<Integer>;
+    Fsize: Integer;
+    procedure InitLookup();
+    function GetBit(i: Integer): Boolean;
+    procedure SetBit(i: Integer; Value: Boolean);
+    function makeArray(Size: Integer): TArray<Integer>;
+    procedure BitArray(bits: TArray<Integer>; size: Integer);
+    procedure ensureCapacity(size: Integer);
+
+
+    function numberOfTrailingZeros(num: Integer): Integer;
+    function GetBits: TArray<Integer>;
+
+  private
+    constructor Create(); overload;
+    constructor Create(const Size: Integer); overload;
+
+  public
+    function Size: Integer;
+    function SizeInBytes: Integer;
+
+    property Self[i: Integer]: Boolean read GetBit write SetBit; default;
+    property Bits: TArray<Integer> read Fbits;
+
+    destructor Destroy; override;
+    function getNextSet(from: Integer): Integer;
+    function getNextUnset(from: Integer): Integer;
+
+    procedure setBulk(i, newBits: Integer);
+   	procedure setRange(start, ending: Integer);
+    procedure appendBit(bit: Boolean);
+    procedure Reverse();
+    procedure clear();
+
+    function isRange(start, ending: Integer;
+      const value: Boolean): Boolean;
+  end;
+
+
+constructor TBitArrayImplementation.Create;
+begin
+  Fsize := 0;
+  SetLength(Fbits, 1);
+  InitLookup();
+end;
+
+constructor TBitArrayImplementation.Create(const Size: Integer);
+begin
+  if (Size < 1)
+  then
+     raise EArgumentException.Create('size must be at least 1.');
+
+  Fsize := Size;
+  Fbits := makeArray(Size);
+  InitLookup();
+end;
+
+// For testing only
+procedure TBitArrayImplementation.BitArray(bits: TArray<Integer>; size: Integer);
+begin
+  Fbits := bits;
+  Fsize := size;
+end;
+
+procedure TBitArrayImplementation.ensureCapacity(size: Integer);
+var
+  newBits : TArray<Integer>;
+begin
+  if (size > TMathUtils.Asr(Length(Fbits), 5)) then
+  begin
+    newBits := makeArray(size);
+    Move(Fbits[0], newBits[0], Length(Fbits));
+    Fbits := newBits;
+  end;
+end;
+
+destructor TBitArrayImplementation.Destroy;
+begin
+  Fbits := nil;
+  _lookup := nil;
+  inherited;
+end;
+
+function TBitArrayImplementation.GetBit(i: Integer): Boolean;
+begin
+  Result := ((Fbits[TMathUtils.Asr(i, 5)]) and (1 shl (i and $1F))) <> 0;
+end;
+
+function TBitArrayImplementation.GetBits: TArray<Integer>;
+begin
+   result := FBits;
+end;
+
+/// <summary>
+/// Gets the next set.
+/// </summary>
+/// <param name="from">first bit to check</param>
+/// <returns>index of first bit that is set, starting from the given index, or size if none are set
+/// at or beyond this given index</returns>
+function TBitArrayImplementation.getNextSet(from: Integer): Integer;
+var
+  bitsOffset,
+  currentBits : Integer;
+begin
+  if (from >= Fsize) then
+  begin
+    Result := Fsize;
+    exit;
+  end;
+  bitsOffset := TMathUtils.Asr(from, 5);
+  currentBits := Fbits[bitsOffset];
+  // mask off lesser bits first
+  currentBits := currentBits and (not((1 shl (from and $1F)) - 1));
+  while (currentBits = 0) do
+  begin
+    Inc(bitsOffset);
+    if (bitsOffset = Length(Fbits)) then
+    begin
+      Result := Fsize;
+      exit;
+    end;
+    currentBits := Fbits[bitsOffset];
+  end;
+
+  Result := (bitsOffset shl 5) + numberOfTrailingZeros(currentBits);
+
+  if (Result > Fsize) then
+  begin
+    Result := Fsize;
+  end;
+
+end;
+
+/// <summary>
+/// see getNextSet(int)
+/// </summary>
+/// <param name="from">index to start looking for unset bit</param>
+/// <returns>index of next unset bit, or <see cref="Size"/> if none are unset until the end</returns>
+function TBitArrayImplementation.getNextUnset(from: Integer): Integer;
+var
+  bitsOffset,
+  currentBits: Integer;
+begin
+  if (from >= Fsize) then
+  begin
+    Result := Fsize;
+    exit;
+  end;
+  bitsOffset := TMathUtils.Asr(from, 5);
+  currentBits := not Fbits[bitsOffset];
+
+  // mask off lesser bits first
+  currentBits := currentBits and (not( (1 shl (from and $1F)) - 1));
+  while (currentBits = 0) do
+  begin
+    Inc(bitsOffset);
+    if (bitsOffset = Length(Fbits)) then
+    begin
+      Result := Size;
+      exit;
+    end;
+    currentBits := not Fbits[bitsOffset];
+  end;
+  Result := (bitsOffset shl 5) + numberOfTrailingZeros(currentBits);
+
+  if (Result > Size)
+  then
+     Result := Size;
+end;
+
+procedure TBitArrayImplementation.InitLookup;
+begin
+  _lookup := TArray<Integer>.Create(32, 0, 1, 26, 2, 23, 27, 0, 3, 16, 24, 30,
+    28, 11, 0, 13, 4, 7, 17, 0, 25, 22, 31, 15, 29, 10, 12, 6, 0, 21, 14, 9, 5,
+    20, 8, 19, 18);
+end;
+
+function TBitArrayImplementation.makeArray(Size: Integer): TArray<Integer>;
+var
+  ar: TArray<Integer>;
+begin
+  SetLength(ar, TMathUtils.Asr((Size + 31), 5));
+  Result := ar;
+end;
+
+function TBitArrayImplementation.numberOfTrailingZeros(num: Integer): Integer;
+var
+  index: Integer;
+begin
+  index := (-num and num) mod 37;
+  if (index < 0) then
+  begin
+    index := index * -1;
+  end;
+  Result := _lookup[index];
+end;
+
+procedure TBitArrayImplementation.Reverse;
+var
+  newBits: TArray<Integer>;
+  i, len, oldBitsLen, leftOffset, mask, nextInt, currentInt: Integer;
+  x: Int64;
+begin
+
+  SetLength(newBits, Length(Fbits));
+  // reverse all int's first
+  len := TMathUtils.Asr((Size - 1), 5);
+  oldBitsLen := len + 1;
+  for i := 0 to oldBitsLen - 1 do
+  begin
+    x := Fbits[i];
+    x := (TMathUtils.Asr(x, 1) and $55555555) or ((x and $55555555) shl 1);
+    x := (TMathUtils.Asr(x, 2) and $33333333) or ((x and $33333333) shl 2);
+    x := (TMathUtils.Asr(x, 4) and $0F0F0F0F) or ((x and $0F0F0F0F) shl 4);
+    x := (TMathUtils.Asr(x, 8) and $00FF00FF) or ((x and $00FF00FF) shl 8);
+    x := (TMathUtils.Asr(x, 16) and $0000FFFF) or ((x and $0000FFFF) shl 16);
+    newBits[len - i] := integer(x) ;
+  end;
+  // now correct the int's if the bit size isn't a multiple of 32
+  if (Size <> oldBitsLen * 32) then
+  begin
+    leftOffset := oldBitsLen * 32 - Size;
+    mask := 1;
+    for i := 0 to 31 - leftOffset - 1 do
+    begin
+      mask := (mask shl 1) or 1;
+    end;
+
+    currentInt := TMathUtils.Asr(newBits[0], leftOffset) and mask;
+    for i := 1 to oldBitsLen - 1 do
+    begin
+      nextInt := newBits[i];
+      currentInt := currentInt or (nextInt shl (32 - leftOffset));
+      newBits[i - 1] := currentInt;
+      currentInt := TMathUtils.Asr(nextInt, leftOffset) and mask;
+    end;
+    newBits[oldBitsLen - 1] := currentInt;
+  end;
+
+  Fbits := newBits;
+end;
+
+procedure TBitArrayImplementation.SetBit(i: Integer; Value: Boolean);
+var
+  index: Integer;
+begin
+  if (Value) then
+  begin
+    index := TMathUtils.Asr(i, 5);
+    Fbits[index] := Fbits[index] or 1 shl (i and $1F);
+  end;
+end;
+
+function TBitArrayImplementation.Size: Integer;
+begin
+  result := FSize;
+end;
+
+function TBitArrayImplementation.SizeInBytes: Integer;
+begin
+  Result := TMathUtils.Asr(Size + 7, 3);
+end;
+
+/// <summary> Sets a block of 32 bits, starting at bit i.
+///
+/// </summary>
+/// <param name="i">first bit to set
+/// </param>
+/// <param name="newBits">the new value of the next 32 bits. Note again that the least-significant bit
+/// corresponds to bit i, the next-least-significant to i+1, and so on.
+/// </param>
+procedure TBitArrayImplementation.setBulk(i, newBits: Integer);
+var
+  r: Integer;
+begin
+  r := TMathUtils.Asr(i, 5);
+  Fbits[r] := newBits;
+end;
+
+/// <summary>
+/// Sets a range of bits.
+/// </summary>
+/// <param name="start">start of range, inclusive.</param>
+/// <param name="ending">end of range, exclusive</param>
+procedure TBitArrayImplementation.setRange(start, ending: Integer);
+var
+  firstInt,
+  lastInt,
+  mask,
+  i, j : Integer;
+  firstBit,
+  lastBit : Integer;
+begin
+  if (ending < start)
+  then
+     raise EArgumentException.Create('Start is greater than end');
+
+  if (ending = start)
+  then
+     exit;
+  Dec(ending); // will be easier to treat this as the last actually set bit -- inclusive
+  firstInt := TMathUtils.Asr(start, 5);
+  lastInt := TMathUtils.Asr(ending, 5);
+  for i := firstInt to lastInt do
+  begin
+    if (i > firstInt)
+    then
+       firstBit := start
+    else
+       firstBit := $1F;
+    if (i < lastInt)
+    then
+       lastBit := 31
+    else
+       lastBit := (ending and $1F);
+
+    if ((firstBit = 0) and (lastBit = 31))
+    then
+       mask := -1
+    else
+    begin
+      mask := 0;
+      for j := firstBit to lastBit do
+      begin
+        mask := (mask or (1 shl j));
+      end;
+    end;
+    bits[i] := (bits[i] or mask);
+  end;
+end;
+
+/// <summary> Clears all bits (sets to false).</summary>
+procedure TBitArrayImplementation.Clear;
+var
+  max,
+  i: Integer;
+begin
+  max := Length(Fbits);
+  for i := 0 to Pred(max) do
+  begin
+    Fbits[i] := 0;
+  end;
+end;
+
+/// <summary> Efficient method to check if a range of bits is set, or not set.
+///
+/// </summary>
+/// <param name="start">start of range, inclusive.
+/// </param>
+/// <param name="ending">end of range, exclusive
+/// </param>
+/// <param name="value">if true, checks that bits in range are set, otherwise checks that they are not set
+/// </param>
+/// <returns> true iff all bits are set or not set in range, according to value argument
+/// </returns>
+/// <throws>  EIllegalArgumentException if end is less than or equal to start </throws>
+function TBitArrayImplementation.isRange(start, ending: Integer;
+  const value: Boolean): Boolean;
+var
+  firstInt,
+  lastInt,
+  firstBit,
+  lastBit,
+  mask,
+  i, j,
+  temp: Integer;
+begin
+  if (ending < start) then
+  begin
+    Result := False; // there is a bug here some how. We just exits with fals
+    //exit;
+    //raise EArgumentException.Create('End is greater then start');
+  end;
+
+  if (ending = start) then
+  begin
+    Result := true; // empty range matches
+    exit;
+  end;
+  Dec(ending); // will be easier to treat this as the last actually set bit -- inclusive
+
+  firstInt := TMathUtils.Asr(start, 5);
+  lastInt := TMathUtils.Asr(ending, 5);
+  for i := firstInt to lastInt do
+  begin
+    if (i > firstInt)
+  	then
+       firstBit := 0
+    else
+       firstBit := (start and $1F);
+
+    if (i < lastInt)
+	  then
+       lastBit := 31
+    else
+       lastBit := (ending and $1F);
+
+    if ((firstBit = 0) and (lastBit = 31))
+  	then
+       mask := -1
+    else
+    begin
+      mask := 0;
+      for j := firstBit to lastBit do
+        mask := mask or (1 shl j);
+    end;
+
+    // Return false if we're looking for 1s and the masked bits[i] isn't all 1s (that is,
+    // equals the mask, or we're looking for 0s and the masked portion is not all 0s
+    if (Value)
+	  then
+       temp := mask
+  	else
+	   temp := 0;
+
+    if ((Fbits[i] and mask) <> (temp)) then
+    begin
+      Result := False;
+      exit;
+    end;
+  end;
+
+  Result := true;
+end;
+
+/// <summary>
+/// Appends the bit.
+/// </summary>
+/// <param name="bit">The bit.</param>
+procedure TBitArrayImplementation.appendBit(bit: Boolean);
+var
+  i: Integer;
+begin
+  ensureCapacity(Fsize + 1);
+  if (bit) then
+  begin
+    i := TMathUtils.Asr(Fsize, 5);
+    bits[i] := (bits[i] or (Fsize and $1F));
+  end;
+  Dec(Fsize);
+end;
+
+
+
+
+function NewBitArray:IBitArray;
+begin
+   result :=  TBitArrayImplementation.Create;
+end;
+
+
+function NewBitArray(const Size: Integer):IBitArray;
+begin
+   result :=  TBitArrayImplementation.Create(size);
+end;
+
+
+end.

--- a/Lib/Classes/Common/ZXing.Common.BitMatrix.pas
+++ b/Lib/Classes/Common/ZXing.Common.BitMatrix.pas
@@ -65,19 +65,21 @@ type
     function getBottomRightOnBit: TArray<Integer>;
     function getEnclosingRectangle: TArray<Integer>;
     function GetHashCode: Integer; override;
-    function getRow(const y: Integer; row: TBitArray): TBitArray;
+    function getRow(const y: Integer; row: IBitArray): IBitArray;
     function getTopLeftOnBit: TArray<Integer>;
     procedure Rotate180;
     procedure setRegion(left: Integer; top: Integer; width: Integer;
       height: Integer);
-    procedure setRow(y: Integer; row: TBitArray);
+    procedure setRow(y: Integer; row: IBitArray);
     function ToBitmap: TBitmap; overload;
     function ToBitmap(format: TBarcodeFormat; content: string)
       : TBitmap; overload;
 
     property width: Integer read Fwidth;
     property height: Integer read Fheight;
-    property Self[x, y: Integer]: Boolean read getBit write setBit; default;
+    property Matrix[x, y: Integer]: Boolean read getBit write setBit; default;
+    // added for debugging
+    function ToString:string; override;
   end;
 
 implementation
@@ -341,13 +343,13 @@ begin
   result := hash;
 end;
 
-function TBitMatrix.getRow(const y: Integer; row: TBitArray): TBitArray;
+function TBitMatrix.getRow(const y: Integer; row: IBitArray): IBitArray;
 var
   x,
   offset: Integer;
 begin
   if ((row = nil) or (row.Size < Self.Fwidth)) then
-    row := TBitArray.Create(Self.Fwidth)
+    row := TBitArrayHelpers.CreateBitArray(Self.Fwidth)
   else
     row.Clear;
   offset := (y * Self.FrowSize);
@@ -399,12 +401,12 @@ var
   width, 
   height     : Integer;
   topRow, 
-  bottomRow  : TBitArray;
+  bottomRow  : IBitArray;
 begin
   width := Self.Fwidth;
   height := Self.Fheight;
-  topRow := TBitArray.Create(width);
-  bottomRow := TBitArray.Create(width);
+  topRow := TBitArrayHelpers.CreateBitArray(width);
+  bottomRow := TBitArrayHelpers.CreateBitArray(width);
   i := 0;
 
   while ((i < ((height + 1) div 2))) do
@@ -454,7 +456,7 @@ begin
   end;
 end;
 
-procedure TBitMatrix.setRow(y: Integer; row: TBitArray);
+procedure TBitMatrix.setRow(y: Integer; row: IBitArray);
 begin
   Fbits := System.Copy(row.bits, (y * FrowSize), FrowSize);
 end;
@@ -462,6 +464,20 @@ end;
 function TBitMatrix.ToBitmap(format: TBarcodeFormat; content: string): TBitmap;
 begin
   raise ENotImplemented.Create('Converting to bitmap is not implemented yet!');
+end;
+
+function TBitMatrix.ToString: string;
+var r,c:integer;
+begin
+   for r := 0 to Fheight -1 do begin
+       for c:= 0 to Fwidth-1 do begin
+         if matrix[r,c]  then
+           result := result + '*'
+         else
+           result := result + '.';
+       end;
+       result := result + #13#10;
+   end;
 end;
 
 function TBitMatrix.ToBitmap: TBitmap;

--- a/Lib/Classes/Common/ZXing.Common.DetectorResult.pas
+++ b/Lib/Classes/Common/ZXing.Common.DetectorResult.pas
@@ -35,19 +35,19 @@ type
   TDetectorResult = class
   private
     Fbits: TBitmatrix;
-    Fpoints: TArray<TResultPoint>;
+    Fpoints: TArray<IResultPoint>;
   public
-    constructor Create(const bits: TBitmatrix; const points: TArray<TResultPoint>);
+    constructor Create(const bits: TBitmatrix; const points: TArray<IResultPoint>);
     destructor Destroy; override;
 
     property bits: TBitmatrix read Fbits;
-    property points: TArray<TResultPoint> read Fpoints;
+    property points: TArray<IResultPoint> read Fpoints;
   end;
 
 implementation
 
 constructor TDetectorResult.Create(const bits: TBitmatrix;
-  const points: TArray<TResultPoint>);
+  const points: TArray<IResultPoint>);
 begin
   Fbits := bits;
   Fpoints := points;

--- a/Lib/Classes/Common/ZXing.ReadResult.pas
+++ b/Lib/Classes/Common/ZXing.ReadResult.pas
@@ -42,7 +42,7 @@ type
     FTimeStamp: TDateTime;
     FResultMetadata: TDictionary<TResultMetadataType, TObject>;
     FRawBytes: TArray<Byte>;
-    FResultPoints: TArray<TResultPoint>;
+    FResultPoints: TArray<IResultPoint>;
     FFormat: TBarcodeFormat;
 
     procedure SetText(const AValue: String);
@@ -55,7 +55,7 @@ type
     /// <param name="resultPoints">The result points.</param>
     /// <param name="format">The format.</param>
     constructor Create(const text: string; const rawBytes: TArray<Byte>;
-      const resultPoints: TArray<TResultPoint>;
+      const resultPoints: TArray<IResultPoint>;
       const format: TBarcodeFormat); overload;
 
     /// <summary>
@@ -67,7 +67,7 @@ type
     /// <param name="format">The format.</param>
     /// <param name="timestamp">The timestamp.</param>
     constructor Create(const text: string; const rawBytes: TArray<Byte>;
-      const resultPoints: TArray<TResultPoint>; const format: TBarcodeFormat;
+      const resultPoints: TArray<IResultPoint>; const format: TBarcodeFormat;
       const timeStamp: TDateTime); overload;
     destructor Destroy; override;
 
@@ -95,7 +95,7 @@ type
     /// Adds the result points.
     /// </summary>
     /// <param name="newPoints">The new points.</param>
-    procedure addResultPoints(const newPoints: TArray<TResultPoint>);
+    procedure addResultPoints(const newPoints: TArray<IResultPoint>);
 
     /// <returns>raw text encoded by the barcode, if applicable, otherwise <code>null</code></returns>
     property text: String read FText write SetText;
@@ -108,7 +108,7 @@ type
     /// identifying finder patterns or the corners of the barcode. The exact meaning is
     /// specific to the type of barcode that was decoded.
     /// </returns>
-    property resultPoints: TArray<TResultPoint> read FResultPoints
+    property resultPoints: TArray<IResultPoint> read FResultPoints
       write FResultPoints;
 
     /// <returns>{@link TBarcodeFormat} representing the format of the barcode that was decoded</returns>
@@ -132,13 +132,13 @@ end;
 { TReadResult }
 
 constructor TReadResult.Create(const text: String; const rawBytes: TArray<Byte>;
-  const resultPoints: TArray<TResultPoint>; const format: TBarcodeFormat);
+  const resultPoints: TArray<IResultPoint>; const format: TBarcodeFormat);
 begin
   Self.Create(text, rawBytes, resultPoints, format, Now);
 end;
 
 constructor TReadResult.Create(const text: String; const rawBytes: TArray<Byte>;
-  const resultPoints: TArray<TResultPoint>; const format: TBarcodeFormat;
+  const resultPoints: TArray<IResultPoint>; const format: TBarcodeFormat;
   const timeStamp: TDateTime);
 begin
   if ((text = '') and (rawBytes = nil)) then
@@ -154,21 +154,8 @@ begin
 end;
 
 destructor TReadResult.Destroy;
-var
-  i: Integer;
-  ResultPoint: TResultPoint;
-  metaData: TPair<TResultMetadataType, TObject>;
 begin
-
-  if (Assigned(FResultPoints)) then
-  begin
-
-    for ResultPoint in FResultPoints do
-      ResultPoint.Free;
-
-    resultPoints := nil;
-  end;
-
+  resultPoints := nil;
   FRawBytes := nil;
 
   if FResultMetadata <> nil then
@@ -213,9 +200,9 @@ begin
   end;
 end;
 
-procedure TReadResult.addResultPoints(const newPoints: TArray<TResultPoint>);
+procedure TReadResult.addResultPoints(const newPoints: TArray<IResultPoint>);
 var
-  oldPoints, allPoints: TArray<TResultPoint>;
+  oldPoints, allPoints: TArray<IResultPoint>;
 begin
   oldPoints := FResultPoints;
   if (oldPoints = nil) then
@@ -224,7 +211,7 @@ begin
   begin
     if (newPoints <> nil) and (Length(newPoints) > 0) then
     begin
-      allPoints := TArray<TResultPoint>.Create();
+      allPoints := TArray<IResultPoint>.Create();
       SetLength(allPoints, (Length(oldPoints) + Length(newPoints)));
 
       Move(oldPoints[0], newPoints[0], Length(oldPoints));

--- a/Lib/Classes/Common/ZXing.ResultPointImplementation.pas
+++ b/Lib/Classes/Common/ZXing.ResultPointImplementation.pas
@@ -1,0 +1,168 @@
+unit ZXing.ResultPointImplementation;
+
+interface
+uses system.SysUtils, 
+     ZXing.ResultPoint;
+
+type
+  /// <summary>
+  /// Encapsulates a point of interest in an image containing a barcode. Typically, this
+  /// would be the location of a finder pattern or the corner of the barcode, for example.
+  /// this class is meant to be used only indirectly, via the IResultPoint reference-counted interface
+  // it implements. It is exposed in the interface section just to allow the declaration of its derived classes
+  /// </summary>
+  TResultPoint = class(TInterfacedObject,IResultPoint)
+  private type
+    TSingleArray = array [0 .. Pred(SizeOf(Single))] of Byte;
+  var
+    Fx, Fy: Single;
+    bytesX, bytesY: TSingleArray;
+    FToString: String;
+    procedure SetX(const AValue: Single);
+    procedure SetY(const AValue: Single);
+    function GetX: Single;
+    function GetY: Single;
+  public
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TResultPoint"/> class.
+    /// </summary>
+    constructor Create; overload;
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TResultPoint"/> class.
+    /// </summary>
+    /// <param name="x">The x.</param>
+    /// <param name="y">The y.</param>
+    constructor Create(const pX, pY: Single); overload;
+    destructor Destroy; override;
+
+    /// <summary>
+    /// Determines whether the specified <see cref="System.TObject"/> is equal to this instance.
+    /// </summary>
+    /// <param name="other">The <see cref="System.TObject"/> to compare with this instance.</param>
+    /// <returns>
+    /// <c>true</c> if the specified <see cref="System.TObject"/> is equal to this instance; otherwise, <c>false</c>.
+    /// </returns>
+    function Equals(other: TObject): Boolean; override;
+    /// <summary>
+    /// Returns a hash code for this instance.
+    /// </summary>
+    /// <returns>
+    /// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
+    /// </returns>
+    function GetHashCode(): Integer; override;
+    /// <summary>
+    /// Returns a <see cref="System.String"/> that represents this instance.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="System.String"/> that represents this instance.
+    /// </returns>
+    function ToString(): String; override;
+
+    property x: Single read GetX write SetX;
+    property y: Single read GetY write SetY;
+  end;
+
+// these are the helping functions that actually create a new instance.
+// The actual constructor cannot be called outside of this unit
+function NewResultPoint:IResultPoint; overload;
+function NewResultPoint(const pX, pY: Single):IResultPoint; overload;
+
+
+implementation
+
+function NewResultPoint:IResultPoint;
+begin
+  result := TResultPoint.Create;
+end;
+
+function NewResultPoint(const pX, pY: Single):IResultPoint;
+begin
+   result := TResultPoint.Create(px,py);
+end;
+
+
+{ TResultPoint }
+
+
+constructor TResultPoint.Create;
+begin
+  inherited;
+end;
+
+constructor TResultPoint.Create(const pX, pY: Single);
+begin
+  inherited Create;
+
+  Fx := pX;
+  Fy := pY;
+  bytesX := TSingleArray(pX);
+  bytesY := TSingleArray(pY);
+end;
+
+destructor TResultPoint.Destroy;
+var
+  n: Single;
+begin
+  n := 0;
+  bytesX := TSingleArray(n);
+  bytesY := TSingleArray(n);
+  inherited;
+end;
+
+procedure TResultPoint.SetX(const AValue: Single);
+begin
+  if (AValue <> Fx) then
+  begin
+    Fx := AValue;
+    bytesX := TSingleArray(Fx);
+  end;
+end;
+
+procedure TResultPoint.SetY(const AValue: Single);
+begin
+  if (AValue <> Fy) then
+  begin
+    Fy := AValue;
+    bytesY := TSingleArray(Fy);
+  end;
+end;
+
+function TResultPoint.GetX: Single;
+begin
+   result := Fx;
+end;
+
+function TResultPoint.GetY: Single;
+begin
+   result := Fy;
+end;
+
+function TResultPoint.Equals(other: TObject): Boolean;
+var
+  otherPoint: TResultPoint;
+begin
+  otherPoint := other as TResultPoint;
+  if (otherPoint = nil) then
+    Result := false
+  else
+    Result := ((otherPoint.x = Fx) and (otherPoint.y = Fy));
+end;
+
+function TResultPoint.GetHashCode: Integer;
+begin
+  Result := 31 * ((bytesX[0] shl 24) + (bytesX[1] shl 16) + (bytesX[2] shl 8) +
+    bytesX[3]) + (bytesY[0] shl 24) + (bytesY[1] shl 16) + (bytesY[2] shl 8) +
+    bytesY[3];
+end;
+
+
+function TResultPoint.ToString: String;
+begin
+  if (FToString = '') then
+    FToString := Format('(%g),(%g)', [Fx, Fy]);
+  Result := FToString;
+end;
+
+
+
+end.

--- a/Lib/Classes/Filtering/Binarizer.pas
+++ b/Lib/Classes/Filtering/Binarizer.pas
@@ -60,7 +60,7 @@ type
     /// <returns> The array of bits for this row (true means black).</returns>
   public
     function LuminanceSource(): TLuminanceSource;
-    function GetBlackRow(y: Integer; row: TBitArray): TBitArray;
+    function GetBlackRow(y: Integer; row: IBitArray): IBitArray;
       virtual; abstract;
 
     function BlackMatrix: TBitMatrix; virtual; abstract;

--- a/Lib/Classes/Filtering/BinaryBitmap.pas
+++ b/Lib/Classes/Filtering/BinaryBitmap.pas
@@ -48,7 +48,7 @@ type
     /// If used, the Binarizer will call BitArray.clear(). Always use the returned object.
     /// </param>
     /// <returns> The array of bits for this row (true means black).</returns>
-    function getBlackRow(y: Integer; row: TBitArray): TBitArray;
+    function getBlackRow(y: Integer; row: IBitArray): IBitArray;
     function RotateSupported: Boolean;
     function rotateCounterClockwise(): TBinaryBitmap;
 
@@ -93,7 +93,7 @@ begin
 
 end;
 
-function TBinaryBitmap.getBlackRow(y: Integer; row: TBitArray): TBitArray;
+function TBinaryBitmap.getBlackRow(y: Integer; row: IBitArray): IBitArray;
 begin
   result := Binarizer.getBlackRow(y, row);
 end;

--- a/Lib/Classes/Filtering/GlobalHistogramBinarizer.pas
+++ b/Lib/Classes/Filtering/GlobalHistogramBinarizer.pas
@@ -44,7 +44,7 @@ type
     constructor Create(source: TLuminanceSource);
 
     // constructor GlobalHistogramBinarizer(source: TLuminanceSource);
-    function GetBlackRow(y: Integer; row: TBitArray): TBitArray; override;
+    function GetBlackRow(y: Integer; row: IBitArray): IBitArray; override;
   end;
 
 implementation
@@ -81,8 +81,8 @@ end;
   end;
 }
 
-function TGlobalHistogramBinarizer.GetBlackRow(y: Integer; row: TBitArray)
-  : TBitArray;
+function TGlobalHistogramBinarizer.GetBlackRow(y: Integer; row: IBitArray)
+  : IBitArray;
 var
   localLuminances: TArray<Byte>;
   localBuckets: TArray<Integer>;
@@ -91,7 +91,7 @@ begin
   w := width;
   if ((row = nil) or (row.Size < w)) then
   begin
-    row := TBitArray.Create(w);
+    row := TBitArrayHelpers.CreateBitArray(w);
   end
   else
   begin

--- a/Lib/Classes/Filtering/ZXing.BaseLuminanceSource.pas
+++ b/Lib/Classes/Filtering/ZXing.BaseLuminanceSource.pas
@@ -45,8 +45,10 @@ type
     function CreateLuminanceSource(const newLuminances: TArray<Byte>;
       const width, height: Integer): TLuminanceSource; virtual; abstract;
   public
-    constructor Create(const width, height: Integer); overload;
-    constructor Create(const luminanceArray: TArray<Byte>; const width, height: Integer); overload;
+    
+    // added the "reintroduce" keyword to shut off the "method hides another method with the same name in the base class"
+    constructor Create(const width, height: Integer);  reintroduce; overload; 
+    constructor Create(const luminanceArray: TArray<Byte>; const width, height: Integer);  reintroduce; overload;
 
     function getRow(const y: Integer; row: TArray<Byte>): TArray<Byte>; override;
     function rotateCounterClockwise(): TLuminanceSource; override;


### PR DESCRIPTION
I re-made what already did on branch Master... there were too much differences, so I did it all again.
**What is is still left to do:**
There still are memory leaks (I didn't address them yet, but they are small, compared to the ones I fixed)  caused by the TReadResult class, when it uses the  `FResultMetadata: TDictionary<TResultMetadataType, TObject>;` member variable.

Since TObjects, with old-gen compilers, are not garbage collected, it is not possible to store instance objects in that dictionary and forget about them: they will never be deallocated.
 That dictionary should become too a TDictionary<TResultMetadataType, IReadResultItem>
 where IReadResultItem should be an interface implemented by a TInterfacedObject class.

 For example TStringObject (declared in the same unit) should become a TInterfacedObject descendant and it should implement a IStringResultItem interface (extended from IReadResultItem).
**SIDE NOTE:** 
There is a worst problem with 64 bit compilation with version 3.0, I will write a proper bug report (or a pull request, if I will find a way to fix it): it seem that, when compiled under 64 bit, the BitMatrix instances (the result of the actual scanning of the source image) are "mangled", so the barcode scanning does not work (at least for qr-codes).
I added this ToString override just for debug purposes: it dumps the bitmap as plain text. I tested the contents of the bitmatrix, while scanning the same qr-code with 32 and 64 bit and I compared them with winmerge... It seems that the first 9-10 lines of the dump are identical, then the 64 bit version starts to read "garbage" for the next 30-40 lines and then it starts again reading correctly for other 9-10 lines and it goes on like that. I suspect that it might be caused by some issues with binary-shift operators. 

function TBitMatrix.ToString: string;
var r,c:integer;
begin
   for r := 0 to Fheight -1 do begin
       for c:= 0 to Fwidth-1 do begin
         if matrix[r,c]  then
           result := result + '*'
         else
           result := result + '.';
       end;
       result := result + #13#10;
   end;
end;
