### PR TITLE
Fixed all memleask I found un Win32/Win64

### DIFF
--- a/Lib/Classes/1D Barcodes/ZXing.OneD.OneDReader.pas
+++ b/Lib/Classes/1D Barcodes/ZXing.OneD.OneDReader.pas
@@ -177,7 +177,7 @@ function TOneDReader.decode(const image: TBinaryBitmap;
 var
   tryHarder, tryHarderWithoutRotation: Boolean;
   rotatedImage: TBinaryBitmap;
-  metadata: TDictionary<TResultMetadataType, TObject>;
+  metadata: TResultMetadata;
   orientation, height, i, l: Integer;
   points: TArray<IResultPoint>;
 
@@ -212,11 +212,14 @@ begin
     begin
       // But if we found it reversed in doDecode(), add in that result here:
       orientation :=
-        (orientation + Integer(metadata[ZXing.ResultMetadataType.orientation]
-        )) mod 360;
+        (
+           orientation
+           +
+           (metadata[ZXing.ResultMetadataType.orientation] as IIntegerMetadata).Value
+        ) mod 360;
     end;
 
-    Result.putMetadata(ZXing.ResultMetadataType.orientation, TObject(orientation));
+    Result.putMetadata(ZXing.ResultMetadataType.orientation, TResultMetaData.CreateIntegerMetadata(orientation));
     // Update result points
     points := Result.ResultPoints;
     if (points <> nil) then

--- a/Lib/Classes/1D Barcodes/ZXing.OneD.UPCEANExtension2Support.pas
+++ b/Lib/Classes/1D Barcodes/ZXing.OneD.UPCEANExtension2Support.pas
@@ -55,8 +55,7 @@ type
     /// </summary>
     /// <param name="raw">raw content of extension</param>
     /// <returns>formatted interpretation of raw content as a {@link TMap} mapping
-    class function parseExtensionString(const raw: String):
-      TDictionary<TResultMetadataType, TObject>; static;
+    class function parseExtensionString(const raw: String): TResultMetadata; static;
   public
     class function decodeRow(const rowNumber: Integer; const row: IBitArray;
       const extensionStartRange: TArray<Integer>): TReadResult;
@@ -88,7 +87,7 @@ var
   ending : Integer;
   resultString : String;
   extensionResult : TReadResult;
-  extensionData : TDictionary<TResultMetadataType, TObject>;
+  extensionData : TResultMetadata;
   resultPoints : TArray<IResultPoint>;
 begin
   Result := nil;
@@ -171,10 +170,9 @@ begin
   Result := rowOffset;
 end;
 
-class function TUPCEANExtension2Support.parseExtensionString(
-  const raw: String): TDictionary<TResultMetadataType, TObject>;
+class function TUPCEANExtension2Support.parseExtensionString(const raw: String): TResultMetadata;
 var
-  dictionary1: TDictionary<TResultMetadataType, TObject>;
+  dictionary1: TResultMetadata;
 begin
   Result := nil;
 
@@ -182,8 +180,8 @@ begin
   then
      exit;
 
-  dictionary1 := TDictionary<TResultMetadataType, TObject>.Create;
-  dictionary1[ZXing.ResultMetadataType.ISSUE_NUMBER] := TObject(raw);
+  dictionary1 := TResultMetadata.Create;
+  dictionary1[ZXing.ResultMetadataType.ISSUE_NUMBER] := TResultMetaData.CreateStringMetadata(raw);
   Result := dictionary1;
 end;
 

--- a/Lib/Classes/1D Barcodes/ZXing.OneD.UPCEANExtension5Support.pas
+++ b/Lib/Classes/1D Barcodes/ZXing.OneD.UPCEANExtension5Support.pas
@@ -64,7 +64,7 @@ type
     /// <returns>formatted interpretation of raw content as a {@link TMap} mapping
     /// one {@link TResultMetadataType} to appropriate value, or {@code nil} if not known</returns>
     class function parseExtensionString(
-      const raw: string): TDictionary<TResultMetadataType, TObject>; static;
+      const raw: string): TResultMetadata; static;
 
     class function parseExtension5String(const raw: String): String; static;
   public
@@ -100,7 +100,7 @@ var
   res : TStringBuilder;
   ending : Integer;
   resultString : String;
-  extensionData : TDictionary<TResultMetadataType, TObject>;
+  extensionData : TResultMetadata;
   resultPoints : TArray<IResultPoint>;
   extensionResult : TReadResult;
 begin
@@ -235,10 +235,10 @@ begin
 end;
 
 class function TUPCEANExtension5Support.parseExtensionString(
-  const raw: String): TDictionary<TResultMetadataType, TObject>;
+  const raw: String): TResultMetadata;
 var
   value: String;
-  dictionary1: TDictionary<TResultMetadataType, TObject>;
+  dictionary1: TResultMetadata;
 begin
   Result := nil;
   if (Length(raw) <> 5)
@@ -246,12 +246,13 @@ begin
      exit;
 
   value := TUPCEANExtension5Support.parseExtension5String(raw);
+
   if (Length(value) = 0)
   then
      Result := nil;
 
-  dictionary1 := TDictionary<TResultMetadataType, TObject>.Create();
-  dictionary1[ZXing.ResultMetadataType.SUGGESTED_PRICE] := TObject(value);
+  dictionary1 := TResultMetadata.Create();
+  dictionary1[ZXing.ResultMetadataType.SUGGESTED_PRICE] := TResultMetadata.CreateStringMetadata(value);
 
   Result := dictionary1;
 end;

--- a/Lib/Classes/1D Barcodes/ZXing.OneD.UPCEANReader.pas
+++ b/Lib/Classes/1D Barcodes/ZXing.OneD.UPCEANReader.pas
@@ -534,7 +534,7 @@ begin
   extensionResult := extensionReader.decodeRow(rowNumber, row, endRange[1]);
   if (extensionResult <> nil) then
   begin
-    decodeResult.putMetadata(TResultMetadataType.UPC_EAN_EXTENSION, TObject(extensionResult.Text));
+    decodeResult.putMetadata(TResultMetadataType.UPC_EAN_EXTENSION, TResultMetaData.CreateStringMetadata(extensionResult.Text));
     decodeResult.putAllMetadata(extensionResult.ResultMetadata);
     decodeResult.addResultPoints(extensionResult.ResultPoints);
     extensionLength := Length(extensionResult.Text);
@@ -569,7 +569,7 @@ begin
         countryID := eanManSupport.lookupCountryIdentifier(resultString);
         if (countryID <> '')
         then
-           decodeResult.putMetadata(TResultMetadataType.POSSIBLE_COUNTRY, TObject(countryID));
+           decodeResult.putMetadata(TResultMetadataType.POSSIBLE_COUNTRY, TResultMetaData.CreateStringMetadata(countryID));
       end;
   end;
 

--- a/Lib/Classes/2D Barcodes/Decoder/ZXing.Datamatrix.Internal.DecodedBitStreamParser.pas
+++ b/Lib/Classes/2D Barcodes/Decoder/ZXing.Datamatrix.Internal.DecodedBitStreamParser.pas
@@ -25,6 +25,7 @@ uses
   System.SysUtils,
   System.Generics.Collections,
   ZXing.DecoderResult,
+  ZXing.ByteSegments,
   ZXing.BitSource;
 
 type
@@ -55,7 +56,7 @@ type
     class function decodeEdifactSegment(bits: TBitSource;
       res: TStringBuilder): boolean;
     class function decodeBase256Segment(bits: TBitSource; res: TStringBuilder;
-      byteSegments: TList < TArray < Byte >> ): boolean;
+      byteSegments:IByteSegments ): boolean;
     class function decodeAsciiSegment(bits: TBitSource; res: TStringBuilder;
       resultTrailer: TStringBuilder; var mode: TMode): boolean;
     class procedure parseTwoBytes(firstByte: Integer; secondByte: Integer;
@@ -75,14 +76,14 @@ class function TDecodedBitStreamParser.decode(bytes: TArray<Byte>)
 var
   bits: TBitSource;
   res, resultTrailer: TStringBuilder;
-  byteSegments: TList<TArray<Byte>>;
+  byteSegments: IByteSegments;
   mode: TMode;
 
 begin
   bits := TBitSource.Create(bytes);
   res := TStringBuilder.Create(100);
   resultTrailer := TStringBuilder.Create(0);
-  byteSegments := TList < TArray < Byte >>.Create();
+  byteSegments :=  ByteSegmentsCreate;
 
   try
 
@@ -136,7 +137,7 @@ begin
           TMode.BASE256_ENCODE:
             begin
               if (not TDecodedBitStreamParser.decodeBase256Segment(bits, res,
-                byteSegments)) then
+                    byteSegments)) then
               begin
                 result := nil;
                 exit;
@@ -431,7 +432,7 @@ end;
 /// See ISO 16022:2006, 5.2.9 and Annex B, B.2
 /// </summary>
 class function TDecodedBitStreamParser.decodeBase256Segment(bits: TBitSource;
-  res: TStringBuilder; byteSegments: TList < TArray < Byte >> ): boolean;
+  res: TStringBuilder; byteSegments: IByteSegments ): boolean;
 var
   i, Count, codewordPosition, d1: Integer;
   bytes: TArray<Byte>;

--- a/Lib/Classes/2D Barcodes/Decoder/ZXing.QrCode.Internal.DecodedBitStreamParser.pas
+++ b/Lib/Classes/2D Barcodes/Decoder/ZXing.QrCode.Internal.DecodedBitStreamParser.pas
@@ -31,6 +31,7 @@ uses
   ZXing.DecoderResult,
   ZXing.CharacterSetECI,
   ZXing.StringUtils,
+  ZXing.ByteSegments,
   ZXing.QrCode.Internal.Mode,
   ZXing.Common.Detector.MathUtils;
 
@@ -60,7 +61,7 @@ type
     class function decodeByteSegment(const bits: TBitSource;
       const res: TStringBuilder; count: Integer;
       const currentCharacterSetECI: TCharacterSetECI;
-      const byteSegments: TList<TArray<Byte>>;
+      const byteSegments: IByteSegments;
       const hints: TDictionary<TDecodeHintType, TObject>): Boolean; static;
 
     /// <summary>
@@ -110,7 +111,7 @@ class function TDecodedBitStreamParser.decode(const bytes: TArray<Byte>;
 var
   Mode: TMode;
   bits: TBitSource;
-  byteSegments: TList<TArray<Byte>>;
+  byteSegments: IByteSegments;
   fc1InEffect: Boolean;
   symbolSequence,
   parityData,
@@ -124,7 +125,7 @@ begin
 
   bits := TBitSource.Create(bytes);
   res := TStringBuilder.Create(50);
-  byteSegments := TList<TArray<Byte>>.Create();
+  byteSegments := ByteSegmentsCreate();
   byteSegments.Capacity := 1;
   symbolSequence := -1;
   parityData := -1;
@@ -329,7 +330,7 @@ end;
 class function TDecodedBitStreamParser.decodeByteSegment(const bits: TBitSource;
   const res: TStringBuilder; count: Integer;
   const currentCharacterSetECI: TCharacterSetECI;
-  const byteSegments: TList<TArray<Byte>>;
+  const byteSegments: IByteSegments;
   const hints: TDictionary<TDecodeHintType, TObject>): Boolean;
 var
   Enc:TEncoding;

--- a/Lib/Classes/2D Barcodes/ZXing.Datamatrix.DataMatrixReader.pas
+++ b/Lib/Classes/2D Barcodes/ZXing.Datamatrix.DataMatrixReader.pas
@@ -77,6 +77,7 @@ type
   end;
 
 implementation
+uses ZXing.ByteSegments;
 
 { TDataMatrixReader }
 
@@ -107,7 +108,7 @@ var
   points: TArray<IResultPoint>;
   bits: TBitMatrix;
   DetectorResult: TDetectorResult;
-  byteSegments: TList<TArray<Byte>>;
+  ByteSegments: IByteSegments;
 begin
   Result := nil;
   DetectorResult := nil;
@@ -149,14 +150,13 @@ begin
     Result := TReadResult.Create(DecoderResult.Text, DecoderResult.RawBytes,
       points, TBarcodeFormat.DATA_MATRIX);
 
-    byteSegments := DecoderResult.byteSegments;
+    ByteSegments := DecoderResult.ByteSegments;
 
-    if (byteSegments <> nil) then
-      Result.putMetadata(TResultMetadataType.BYTE_SEGMENTS, byteSegments);
+    if (ByteSegments <> nil) then
+      Result.putMetadata(TResultMetadataType.BYTE_SEGMENTS, TResultMetaData.CreateByteSegmentsMetadata( byteSegments));
 
     if (Length(DecoderResult.ECLevel) <> 0) then
-      Result.putMetadata(TResultMetadataType.ERROR_CORRECTION_LEVEL,
-        TStringObject.Create(DecoderResult.ECLevel));
+      Result.putMetadata(TResultMetadataType.ERROR_CORRECTION_LEVEL, TResultMetaData.CreateStringMetadata(DecoderResult.ECLevel));
 
   finally
 

--- a/Lib/Classes/2D Barcodes/ZXing.QrCode.QRCodeReader.pas
+++ b/Lib/Classes/2D Barcodes/ZXing.QrCode.QRCodeReader.pas
@@ -100,6 +100,7 @@ type
   end;
 
 implementation
+uses ZXing.ByteSegments;
 
 { TQRCodeReader }
 
@@ -131,7 +132,7 @@ var
   bits: TBitMatrix;
   DetectorResult: TDetectorResult;
   data: TQRCodeDecoderMetaData;
-  byteSegments: TList<TArray<Byte>>;
+  byteSegments: IByteSegments;
 begin
   Result := nil;
   DecoderResult := nil;
@@ -185,18 +186,17 @@ begin
     byteSegments := DecoderResult.byteSegments;
 
     if (byteSegments <> nil) then
-      Result.putMetadata(TResultMetadataType.BYTE_SEGMENTS, byteSegments);
+      Result.putMetadata(TResultMetadataType.BYTE_SEGMENTS,  TResultMetaData.CreateByteSegmentsMetadata(byteSegments));
 
     if (Length(DecoderResult.ecLevel) <> 0) then
-      Result.putMetadata(TResultMetadataType.ERROR_CORRECTION_LEVEL,
-        TStringObject.Create(DecoderResult.ecLevel));
+      Result.putMetadata(TResultMetadataType.ERROR_CORRECTION_LEVEL, TResultMetaData.CreateStringMetadata(DecoderResult.ecLevel));
 
     if (DecoderResult.StructuredAppend) then
     begin
       Result.putMetadata(TResultMetadataType.STRUCTURED_APPEND_SEQUENCE,
-        TObject(DecoderResult.StructuredAppendSequenceNumber));
+          TResultMetaData.CreateIntegerMetadata(DecoderResult.StructuredAppendSequenceNumber));
       Result.putMetadata(TResultMetadataType.STRUCTURED_APPEND_PARITY,
-        TObject(DecoderResult.StructuredAppendParity))
+        TResultMetaData.CreateIntegerMetadata(DecoderResult.StructuredAppendParity))
     end;
 
   finally

--- a/Lib/Classes/Common/ZXIng.ByteSegments.pas
+++ b/Lib/Classes/Common/ZXIng.ByteSegments.pas
@@ -1,0 +1,89 @@
+unit ZXIng.ByteSegments;
+interface
+
+type
+    /// <summary>
+    ///  implements the ByteSegments (which was declared as a TList<TArray<Byte>>
+    ///  throughout the code as reference-counted interface object)
+    /// </summary>
+    IByteSegments = Interface
+        ['{0994FC90-E8F5-40D8-8A48-9B05DFFF2635}']
+        function Count:integer;
+        procedure Clear;
+        function GetCapacity: integer;
+        procedure SetCapacity(const Value: integer);
+        property Capacity:integer read GetCapacity write SetCapacity;
+        function Add(const item:TArray<byte>):integer;
+     end;
+
+
+function ByteSegmentsCreate:IByteSegments;
+
+implementation
+uses system.SysUtils,
+     Generics.Collections;
+
+type
+  TByteSegments = class(TInterfacedObject,IByteSegments)
+  private
+     FList: TList<TArray<Byte>>;
+     function Count:integer;
+     procedure Clear;
+     constructor Create;
+     function GetCapacity: integer;
+     procedure SetCapacity(const Value: integer);
+     function Add(const item:TArray<byte>):integer;
+  public
+     destructor Destroy; override;
+  end;
+
+
+
+
+function ByteSegmentsCreate:IByteSegments;
+begin
+   result := TByteSegments.Create;
+
+end;
+
+
+{ TByteSegments }
+
+function TByteSegments.Add(const item: TArray<byte>): integer;
+begin
+   result := FList.Add(item);
+end;
+
+procedure TByteSegments.Clear;
+begin
+   FList.Clear;
+end;
+
+function TByteSegments.Count: integer;
+begin
+   result := FList.Count;
+end;
+
+constructor TByteSegments.Create;
+begin
+   FList := TList<TArray<Byte>>.Create;
+   inherited Create;
+end;
+
+destructor TByteSegments.Destroy;
+begin
+  FList.Free;
+  inherited;
+end;
+
+function TByteSegments.GetCapacity: integer;
+begin
+   result := FList.Capacity;
+end;
+
+procedure TByteSegments.SetCapacity(const Value: integer);
+begin
+  FList.Capacity := value;
+end;
+
+end.

--- a/Lib/Classes/Common/ZXing.DecoderResult.pas
+++ b/Lib/Classes/Common/ZXing.DecoderResult.pas
@@ -19,14 +19,16 @@ unit ZXing.DecoderResult;
 }
 interface
 
-uses SysUtils, Generics.Collections;
+uses SysUtils,
+     Generics.Collections,
+     ZXIng.ByteSegments;
 
 type
   TDecoderResult = class
   private
     function GetStructuredAppend: boolean;
   public
-    ByteSegments: TList<TArray<Byte>>;
+    ByteSegments: IByteSegments;
     ECLevel: string;
     Erasures: Integer;
     ErrorsCorrected: Integer;
@@ -37,9 +39,9 @@ type
     Text: string;
 
     constructor Create(RawBytes: TArray<Byte>; const Text: string;
-      ByteSegments: TList<TArray<Byte>>; ECLevel: string); overload;
+      ByteSegments: IByteSegments; ECLevel: string); overload;
     constructor Create(RawBytes: TArray<Byte>; const Text: string;
-      ByteSegments: TList<TArray<Byte>>; ECLevel: string; saSequence: Integer;
+      ByteSegments: IByteSegments; ECLevel: string; saSequence: Integer;
       saParity: Integer); overload;
     destructor Destroy; override;
 
@@ -51,13 +53,13 @@ implementation
 { TDecoderResult }
 
 constructor TDecoderResult.Create(RawBytes: TArray<Byte>; const Text: String;
-  ByteSegments: TList<TArray<Byte>>; ECLevel: String);
+  ByteSegments: IByteSegments; ECLevel: String);
 begin
   Self.Create(RawBytes, Text, ByteSegments, ECLevel, -1, -1);
 end;
 
 constructor TDecoderResult.Create(RawBytes: TArray<Byte>; const Text: string;
-  ByteSegments: TList<TArray<Byte>>; ECLevel: string;
+  ByteSegments: IByteSegments; ECLevel: string;
   saSequence, saParity: Integer);
 begin
   if ((RawBytes = nil) and (Text = ''))
@@ -77,7 +79,7 @@ begin
   if Assigned(ByteSegments)
   then
      ByteSegments.Clear;
-  FreeAndNil(ByteSegments);
+
   RawBytes := nil;
   FreeAndNil(Other);
 

--- a/Lib/Classes/ZXing.ScanManager.pas
+++ b/Lib/Classes/ZXing.ScanManager.pas
@@ -72,7 +72,7 @@ end;
 procedure TScanManager.SetResultPointEvent(const AValue: TResultPointCallback);
 var
   ahKey: TDecodeHintType;
-  a: TResultPointCallback;
+//   a: TResultPointCallback; never used
   ahValue: TObject;
 begin
   FResultPointEvent := AValue;

--- a/MemLeakTest/MainForm.pas
+++ b/MemLeakTest/MainForm.pas
@@ -53,6 +53,7 @@ var
 
 implementation
 
+
 {$R *.fmx}
 { TForm2 }
 
@@ -62,7 +63,8 @@ var
   bmp: TBitmap;
   ScanManager: TScanManager;
   rs: TReadResult;
-  obj : TObject;
+  obj : IMetaData;
+  strMetadata: IStringMetaData;
   ResultPoint: IResultPoint;
 const
   iSize = 5;
@@ -80,9 +82,9 @@ begin
           rs.ResultMetaData.ContainsKey(TResultMetaDataType.ERROR_CORRECTION_LEVEL) then
       begin
         obj := rs.ResultMetaData.Items[TResultMetaDataType.ERROR_CORRECTION_LEVEL];
-        if (obj is TStringObject)
+        if Supports(obj,IStringMetaData,strMetadata)
         then
-           edResult.Text := edResult.Text + ' (ECLevel: ' + TStringObject(obj).Value + ')';
+           edResult.Text := edResult.Text + ' (ECLevel: ' + strMetadata.Value + ')';
       end;
       bmp.Canvas.BeginScene;
       try

--- a/UnitTest/dUnitXTest.dpr
+++ b/UnitTest/dUnitXTest.dpr
@@ -82,7 +82,8 @@ uses
   ZXing.Common.BitArrayImplementation in '..\Lib\Classes\Common\ZXing.Common.BitArrayImplementation.pas',
   ZXing.ResultPointImplementation in '..\Lib\Classes\Common\ZXing.ResultPointImplementation.pas',
   ZXing.QrCode.Internal.AlignmentPatternImplementation in '..\Lib\Classes\2D Barcodes\Detector\ZXing.QrCode.Internal.AlignmentPatternImplementation.pas',
-  ZXing.QrCode.Internal.FinderPatternImplementation in '..\Lib\Classes\2D Barcodes\Detector\ZXing.QrCode.Internal.FinderPatternImplementation.pas';
+  ZXing.QrCode.Internal.FinderPatternImplementation in '..\Lib\Classes\2D Barcodes\Detector\ZXing.QrCode.Internal.FinderPatternImplementation.pas',
+  ZXIng.ByteSegments in '..\Lib\Classes\Common\ZXIng.ByteSegments.pas';
 
 var
   runner : ITestRunner;

--- a/aTestApp/aTestApp.dpr
+++ b/aTestApp/aTestApp.dpr
@@ -74,7 +74,8 @@ uses
   ZXing.Common.BitArrayImplementation in '..\Lib\Classes\Common\ZXing.Common.BitArrayImplementation.pas',
   ZXing.ResultPointImplementation in '..\Lib\Classes\Common\ZXing.ResultPointImplementation.pas',
   ZXing.QrCode.Internal.AlignmentPattern in '..\Lib\Classes\2D Barcodes\Detector\ZXing.QrCode.Internal.AlignmentPattern.pas',
-  ZXing.QrCode.Internal.FinderPattern in '..\Lib\Classes\2D Barcodes\Detector\ZXing.QrCode.Internal.FinderPattern.pas';
+  ZXing.QrCode.Internal.FinderPattern in '..\Lib\Classes\2D Barcodes\Detector\ZXing.QrCode.Internal.FinderPattern.pas',
+  ZXIng.ByteSegments in '..\Lib\Classes\Common\ZXIng.ByteSegments.pas';
 
 {$R *.res}
 


### PR DESCRIPTION
Ok, Applying the usual trick of TInterfacedObject (i'm kinda starting to love the next-gen compilers too) i fixed all the memory leaks that were left.

 The Memory leak I was experiencing was caused by the TStringObject class used to put strings (wrapped in TStringObject instances) inside `FResultMetadata: TDictionary<TResultMetadataType, TObject>;`

 I started to redeclare this varible as  TDictionary<TResultMetadataType, IMetaData>, creating different specialized interfaces of IMetaData depending on the type of data to be stored.
  Since TDictionary<TResultMetadataType, IMetaData> was used throughout the code, I preferred to declare a expliciy type for it and I called it TResultMetadata.

 Going on with writing this fix I discovered that one of the classes that could be stored in metadata was an instance of TList<TArray<Byte>>... which needed too to be declared as an interfaced object.
 I replaced this TList<TArray<Byte>> with a specific interface (declared in its own unit) called IByteSegments.

 This is a breaking change since now client code accessing TReadResult.metadata must be modified for handling IMetaData interface instances and not generic TObjects.

 By the way the previous implementation was not that "safe" since:
1. there was no way, at runtime, to know if some metadata was an integer or an actual object: you can't set an object pointer to "TObject(10)"  and then write "if p is Integer": there is no "autoboxing" in old gen compilers... And I don't even know if there it is in new-gen compiler. under old-gen compilers that is a brutal blind cast from integer to pointer.
2. In some parts of the code TStringObject was not used to wrap strings, so there were cases where was still done a brutal cast from string to TObject (see  TUPCEANExtension2Support.parseExtensionString, for example)
