### PR TITLE
Update main.pas

### DIFF
--- a/demo/aTestApp/main.pas
+++ b/demo/aTestApp/main.pas
@@ -137,6 +137,7 @@ begin
     (AGrantResults[0] = TPermissionStatus.Granted) then
   begin
     CameraComponent1.Active := false;
+    CameraComponent1.Quality := FMX.Media.TVideoCaptureQuality.highQuality;
     CameraComponent1.Quality := FMX.Media.TVideoCaptureQuality.MediumQuality;
     CameraComponent1.Kind := FMX.Media.TCameraKind.BackCamera;
     CameraComponent1.FocusMode := FMX.Media.TFocusMode.ContinuousAutoFocus;


### PR DESCRIPTION
Tested on my android device: when someone reopens the camera it automatically gets high quality, making it appear slow on the screen. Adding this line will make the camera open again from high quality to medium quality, thus appearing faster.