### PR TITLE
Using standard Delphi conditional define instead of custom

### DIFF
--- a/Lib/Classes/Common/ZXing.Common.BitMatrix.pas
+++ b/Lib/Classes/Common/ZXing.Common.BitMatrix.pas
@@ -23,10 +23,10 @@ interface
 
 uses
   SysUtils,
-{$IFDEF USE_VCL_BITMAP}
-  VCL.Graphics,
-{$ELSE}
+{$IFDEF FMX}
   FMX.Graphics,
+{$ELSE}
+  VCL.Graphics,
 {$ENDIF}
   Generics.Collections,
   ZXing.Common.BitArray,

--- a/Lib/Classes/Filtering/ZXing.BaseLuminanceSource.pas
+++ b/Lib/Classes/Filtering/ZXing.BaseLuminanceSource.pas
@@ -23,10 +23,10 @@ interface
 uses
   System.SysUtils,
   System.UITypes,
-{$IFDEF USE_VCL_BITMAP}
-  VCL.Graphics,
-{$ELSE}
+{$IFDEF FMX}
   FMX.Graphics,
+{$ELSE}
+  VCL.Graphics,
 {$ENDIF}
   ZXing.LuminanceSource,
   ZXing.InvertedLuminanceSource;

--- a/Lib/Classes/Filtering/ZXing.RGBLuminanceSource.pas
+++ b/Lib/Classes/Filtering/ZXing.RGBLuminanceSource.pas
@@ -24,11 +24,11 @@ uses
   System.SysUtils,
   System.UITypes,
   System.TypInfo,
-{$IFDEF USE_VCL_BITMAP}
+{$IFDEF FMX}
+  FMX.Graphics,
+{$ELSE}
   Winapi.Windows,
   VCL.Graphics,
-{$ELSE}
-  FMX.Graphics,
 {$ENDIF}
   ZXing.LuminanceSource,
   ZXing.BaseLuminanceSource,

--- a/Lib/Classes/ZXing.ScanManager.pas
+++ b/Lib/Classes/ZXing.ScanManager.pas
@@ -5,10 +5,10 @@ interface
 uses
   System.SysUtils,
   System.Generics.Collections,
-{$IFDEF USE_VCL_BITMAP}
-  VCL.Graphics,
-{$ELSE}
+{$IFDEF FMX}
   FMX.Graphics,
+{$ELSE}
+  VCL.Graphics,
 {$ENDIF}
   ZXing.LuminanceSource,
   ZXing.RGBLuminanceSource,


### PR DESCRIPTION
By using the standard conditional define, there is no need to define custom in every project that uses ZXing