### PR TITLE
Simplify Procedure 'addResultPoints' using array concatenation

### DIFF
--- a/Lib/Classes/Common/ZXing.ReadResult.pas
+++ b/Lib/Classes/Common/ZXing.ReadResult.pas
@@ -323,20 +323,8 @@ begin
 end;
 
 procedure TReadResult.addResultPoints(const newPoints: TArray<IResultPoint>);
-var
-  oldPoints, allPoints: TArray<IResultPoint>;
 begin
-  oldPoints := FResultPoints;
-  if (oldPoints = nil) then
-    FResultPoints := newPoints
-  else
-  begin
-    if (newPoints <> nil) and (Length(newPoints) > 0) then
-    begin
-      TArray.Copy<IResultPoint>(oldPoints, allPoints, 0, 0, Length(oldPoints));
-      TArray.Copy<IResultPoint>(newPoints, allPoints, 0, Length(oldPoints), Length(newPoints));
-    end;
-  end;
+  FResultPoints := FResultPoints + newPoints;
 end;
 
 /// <summary>


### PR DESCRIPTION
Replace the complex logic in TReadResult.addResultPoints with a direct array concatenation operation to fix the EArgumentOutOfRange error
fixes Spelt/ZXing.Delphi#158